### PR TITLE
refactor fetching parent harbor instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,19 +13,19 @@ A Kubernetes operator for managing [Goharbor](https://github.com/goharbor/harbor
 ##### This project is still under development and not stable yet - breaking changes may happen at any time and without notice
 ## Features
 
-**Easy deployment & scaling**: Every Harbor instance is bound only to the deployed Custom Resource.
+**Easy Harbor deployment & scaling**: Every Harbor instance is bound only to the deployed Custom Resource.
 The operator utilizes a [helm client](https://github.com/mittwald/go-helm-client) library for the management of these instances
 
-**Custom chart repositories**: If you need to install a customized or private [harbor helm chart](https://github.com/goharbor/harbor-helm), the `instancechartrepo` resource allows you to do so
+**Custom chart repositories**: If you need to install a customized or private [Harbor helm chart](https://github.com/goharbor/harbor-helm), the `instancechartrepo` resource allows you to do so
 
-**Harbor resource reconciliation**: This operator automatically manages the following goharbor components by utilizing a custom [harbor client library](https://github.com/mittwald/goharbor-client):
+**Harbor resource reconciliation**: This operator automatically manages the following Harbor components by utilizing a custom [harbor client library](https://github.com/mittwald/goharbor-client):
 
 - users
 - repositories
 - replications
 - registries
 
-**Helm Chart**: A Helm chart of this operator can be found under [./deploy/helm-chart/harbor-operator](./deploy/helm-chart/harbor-operator)
+**Helm Chart**: [Installation Guide](#Helm)
 
 ## CRDs
 - registriesv1alpha1:
@@ -37,8 +37,19 @@ The operator utilizes a [helm client](https://github.com/mittwald/go-helm-client
     - registries.registries.mittwald.de
     
 ### Installation
+
 To get an overview of the individual resources that come this operator, take a look at the [examples directory](./examples).
  
+#### Helm
+The helm chart of this operator can be found under [./deploy/helm-chart/harbor-operator](./deploy/helm-chart/harbor-operator).
+
+Alternatively, you can use the the [Mittwald Kubernetes Helm Charts](https://helm.mittwald.de) repository:
+```bash
+helm repo add mittwald https://helm.mittwald.de
+helm repo update
+helm install harbor-operator mittwald/harbor-operator --namespace my-namespace
+```
+
 #### Web UI
 For a trouble-free experience, a valid TLS certificate is required.
 

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ A Kubernetes operator for managing [Goharbor](https://github.com/goharbor/harbor
 
 [![GitHub license](https://img.shields.io/github/license/mittwald/harbor-operator.svg)](https://github.com/mittwald/harbor-operator/blob/master/LICENSE)
 
+[![Docker Repository on Quay](https://quay.io/repository/mittwald/harbor-operator/status "Docker Repository on Quay")](https://quay.io/repository/mittwald/harbor-operator)
+
+[![Maintainability](https://api.codeclimate.com/v1/badges/6208714b76fca48ea633/maintainability)](https://codeclimate.com/github/mittwald/harbor-operator/maintainability)
+
+[![Test Coverage](https://api.codeclimate.com/v1/badges/6208714b76fca48ea633/test_coverage)](https://codeclimate.com/github/mittwald/harbor-operator/test_coverage)
+
 ##### This project is still under development and not stable yet - breaking changes may happen at any time and without notice
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ helm repo update
 helm install harbor-operator mittwald/harbor-operator --namespace my-namespace
 ```
 
+#### Documentation
+For more specific documentation, please refer to the [godoc](https://pkg.go.dev/github.com/mittwald/harbor-operator) of this repository
+
 #### Web UI
 For a trouble-free experience, a valid TLS certificate is required.
 

--- a/pkg/controller/instance/instance_controller.go
+++ b/pkg/controller/instance/instance_controller.go
@@ -78,7 +78,7 @@ func (r *ReconcileInstance) Reconcile(request reconcile.Request) (reconcile.Resu
 
 	ctx := context.Background()
 
-	// Fetch the Instance instance
+	// Fetch the Instance
 	harbor := &registriesv1alpha1.Instance{}
 	if err := r.client.Get(ctx, request.NamespacedName, harbor); err != nil {
 		if errors.IsNotFound(err) {

--- a/pkg/controller/internal/harbor_commons.go
+++ b/pkg/controller/internal/harbor_commons.go
@@ -15,11 +15,11 @@ type ErrInstanceNotFound string
 type ErrInstanceNotReady string
 
 func (e ErrInstanceNotFound) Error() string {
-	return fmt.Sprintf("instance '%s' not found", e)
+	return fmt.Sprintf("instance '%s' not found", string(e))
 }
 
 func (e ErrInstanceNotReady) Error() string {
-	return fmt.Sprintf("instance '%s' not ready", e)
+	return fmt.Sprintf("instance '%s' not ready", string(e))
 }
 
 var ErrUserNotFound = errors.New("user not found")

--- a/pkg/controller/registry/registry_controller.go
+++ b/pkg/controller/registry/registry_controller.go
@@ -98,11 +98,10 @@ func (r *ReconcileRegistry) Reconcile(request reconcile.Request) (reconcile.Resu
 	// Fetch the Instance
 	harbor, err := internal.FetchReadyHarborInstance(ctx, registry.Namespace, registry.Spec.ParentInstance.Name, r.client)
 	if err != nil {
-		if err == internal.ErrInstanceNotFound {
+		if err == internal.ErrInstanceNotFound(registry.Spec.ParentInstance.Name) {
 			registry.Status = registriesv1alpha1.RegistryStatus{Name: string(registriesv1alpha1.RegistryStatusPhaseCreating)}
-			// Requeue, the instance might not have been created yet
-			return reconcile.Result{RequeueAfter: time.Second * 30}, nil
-		} else if err == internal.ErrInstanceNotReady {
+			return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+		} else if err == internal.ErrInstanceNotReady(registry.Spec.ParentInstance.Name) {
 			return reconcile.Result{RequeueAfter: 120 * time.Second}, err
 		} else {
 			registry.Status = registriesv1alpha1.RegistryStatus{LastTransition: &now}

--- a/pkg/controller/registry/registry_controller.go
+++ b/pkg/controller/registry/registry_controller.go
@@ -2,7 +2,6 @@ package registry
 
 import (
 	"context"
-	"fmt"
 	"net/url"
 	"reflect"
 	"time"
@@ -16,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -98,36 +96,21 @@ func (r *ReconcileRegistry) Reconcile(request reconcile.Request) (reconcile.Resu
 	originalRegistry := registry.DeepCopy()
 
 	// Fetch the Instance
-	harbor := &registriesv1alpha1.Instance{}
-	ns := types.NamespacedName{
-		Namespace: registry.Namespace,
-		Name:      registry.Spec.ParentInstance.Name,
-	}
-	err = r.client.Get(ctx, ns, harbor)
-	if errors.IsNotFound(err) {
-		registry.Status = registriesv1alpha1.RegistryStatus{
-			Name:           string(registriesv1alpha1.RegistryStatusPhaseCreating),
-			Message:        "corresponding harbor instance does not exist",
-			LastTransition: &now,
+	harbor, err := internal.FetchReadyHarborInstance(ctx, registry.Namespace, registry.Spec.ParentInstance.Name, r.client)
+	if err != nil {
+		if err == internal.ErrInstanceNotFound {
+			registry.Status = registriesv1alpha1.RegistryStatus{Name: string(registriesv1alpha1.RegistryStatusPhaseCreating)}
+			// Requeue, the instance might not have been created yet
+			return reconcile.Result{RequeueAfter: time.Second * 30}, nil
+		} else if err == internal.ErrInstanceNotReady {
+			return reconcile.Result{RequeueAfter: 120 * time.Second}, err
+		} else {
+			registry.Status = registriesv1alpha1.RegistryStatus{LastTransition: &now}
 		}
 		res, err := r.patchRegistry(ctx, originalRegistry, registry)
 		if err != nil {
 			return res, err
 		}
-		// Requeue, Instance might not have been created yet
-		return reconcile.Result{RequeueAfter: time.Second * 30}, nil
-	} else if err != nil {
-		registry.Status = registriesv1alpha1.RegistryStatus{
-			Name:           string(registriesv1alpha1.RegistryStatusPhaseUnknown),
-			Message:        "could not get existing harbor instance",
-			LastTransition: &now,
-		}
-		return r.patchRegistry(ctx, originalRegistry, registry)
-	}
-
-	// Reconcile only if the corresponding harbor instance is in 'Ready' state
-	if harbor.Status.Phase.Name != registriesv1alpha1.InstanceStatusPhaseReady {
-		return reconcile.Result{RequeueAfter: 120 * time.Second}, fmt.Errorf("parent instance %s/%s is not ready", harbor.Namespace, harbor.Name)
 	}
 
 	// Build a client to connet to the harbor API

--- a/pkg/controller/registry/registry_controller.go
+++ b/pkg/controller/registry/registry_controller.go
@@ -98,10 +98,10 @@ func (r *ReconcileRegistry) Reconcile(request reconcile.Request) (reconcile.Resu
 	// Fetch the Instance
 	harbor, err := internal.FetchReadyHarborInstance(ctx, registry.Namespace, registry.Spec.ParentInstance.Name, r.client)
 	if err != nil {
-		if err == internal.ErrInstanceNotFound(registry.Spec.ParentInstance.Name) {
+		if _, ok := err.(internal.ErrInstanceNotFound); ok {
 			registry.Status = registriesv1alpha1.RegistryStatus{Name: string(registriesv1alpha1.RegistryStatusPhaseCreating)}
 			return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
-		} else if err == internal.ErrInstanceNotReady(registry.Spec.ParentInstance.Name) {
+		} else if _, ok := err.(internal.ErrInstanceNotReady); ok {
 			return reconcile.Result{RequeueAfter: 120 * time.Second}, err
 		} else {
 			registry.Status = registriesv1alpha1.RegistryStatus{LastTransition: &now}

--- a/pkg/controller/replication/replication_controller.go
+++ b/pkg/controller/replication/replication_controller.go
@@ -98,11 +98,11 @@ func (r *ReconcileReplication) Reconcile(request reconcile.Request) (reconcile.R
 	// Fetch the Instance
 	harbor, err := internal.FetchReadyHarborInstance(ctx, replication.Namespace, replication.Spec.ParentInstance.Name, r.client)
 	if err != nil {
-		if err == internal.ErrInstanceNotFound {
+		if err == internal.ErrInstanceNotFound(replication.Spec.ParentInstance.Name) {
 			replication.Status = registriesv1alpha1.ReplicationStatus{Name: string(registriesv1alpha1.ReplicationStatusPhaseCreating)}
 			// Requeue, the instance might not have been created yet
-			return reconcile.Result{RequeueAfter: time.Second * 30}, nil
-		} else if err == internal.ErrInstanceNotReady {
+			return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+		} else if err == internal.ErrInstanceNotReady(replication.Spec.ParentInstance.Name) {
 			return reconcile.Result{RequeueAfter: 120 * time.Second}, err
 		} else {
 			replication.Status = registriesv1alpha1.ReplicationStatus{LastTransition: &now}

--- a/pkg/controller/replication/replication_controller.go
+++ b/pkg/controller/replication/replication_controller.go
@@ -98,11 +98,11 @@ func (r *ReconcileReplication) Reconcile(request reconcile.Request) (reconcile.R
 	// Fetch the Instance
 	harbor, err := internal.FetchReadyHarborInstance(ctx, replication.Namespace, replication.Spec.ParentInstance.Name, r.client)
 	if err != nil {
-		if err == internal.ErrInstanceNotFound(replication.Spec.ParentInstance.Name) {
+		if _, ok := err.(internal.ErrInstanceNotFound); ok {
 			replication.Status = registriesv1alpha1.ReplicationStatus{Name: string(registriesv1alpha1.ReplicationStatusPhaseCreating)}
 			// Requeue, the instance might not have been created yet
 			return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
-		} else if err == internal.ErrInstanceNotReady(replication.Spec.ParentInstance.Name) {
+		} else if _, ok := err.(internal.ErrInstanceNotReady); ok {
 			return reconcile.Result{RequeueAfter: 120 * time.Second}, err
 		} else {
 			replication.Status = registriesv1alpha1.ReplicationStatus{LastTransition: &now}

--- a/pkg/controller/replication/replication_controller.go
+++ b/pkg/controller/replication/replication_controller.go
@@ -15,7 +15,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -97,36 +96,21 @@ func (r *ReconcileReplication) Reconcile(request reconcile.Request) (reconcile.R
 	originalReplication := replication.DeepCopy()
 
 	// Fetch the Instance
-	harbor := &registriesv1alpha1.Instance{}
-	ns := types.NamespacedName{
-		Namespace: replication.Namespace,
-		Name:      replication.Spec.ParentInstance.Name,
-	}
-	err = r.client.Get(ctx, ns, harbor)
-	if errors.IsNotFound(err) {
-		replication.Status = registriesv1alpha1.ReplicationStatus{
-			Name:           string(registriesv1alpha1.ReplicationStatusPhaseCreating),
-			Message:        "corresponding harbor instance does not exist",
-			LastTransition: &now,
+	harbor, err := internal.FetchReadyHarborInstance(ctx, replication.Namespace, replication.Spec.ParentInstance.Name, r.client)
+	if err != nil {
+		if err == internal.ErrInstanceNotFound {
+			replication.Status = registriesv1alpha1.ReplicationStatus{Name: string(registriesv1alpha1.ReplicationStatusPhaseCreating)}
+			// Requeue, the instance might not have been created yet
+			return reconcile.Result{RequeueAfter: time.Second * 30}, nil
+		} else if err == internal.ErrInstanceNotReady {
+			return reconcile.Result{RequeueAfter: 120 * time.Second}, err
+		} else {
+			replication.Status = registriesv1alpha1.ReplicationStatus{LastTransition: &now}
 		}
 		res, err := r.patchReplication(ctx, originalReplication, replication)
 		if err != nil {
 			return res, err
 		}
-		// Requeue, Instance might not have been created yet
-		return reconcile.Result{RequeueAfter: time.Second * 30}, nil
-	} else if err != nil {
-		replication.Status = registriesv1alpha1.ReplicationStatus{
-			Name:           string(registriesv1alpha1.ReplicationStatusPhaseUnknown),
-			Message:        "could not get existing harbor instance",
-			LastTransition: &now,
-		}
-		return r.patchReplication(ctx, originalReplication, replication)
-	}
-
-	// Reconcile only if the corresponding harbor instance is in 'Ready' state
-	if harbor.Status.Phase.Name != registriesv1alpha1.InstanceStatusPhaseReady {
-		return reconcile.Result{RequeueAfter: 120 * time.Second}, fmt.Errorf("parent instance %s/%s is not ready", harbor.Namespace, harbor.Name)
 	}
 
 	// Build a client to connet to the harbor API

--- a/pkg/controller/repository/repository_controller.go
+++ b/pkg/controller/repository/repository_controller.go
@@ -2,7 +2,6 @@ package repository
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"time"
 
@@ -15,7 +14,6 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
@@ -110,36 +108,21 @@ func (r *ReconcileRepository) Reconcile(request reconcile.Request) (reconcile.Re
 	originalRepository := repository.DeepCopy()
 
 	// Fetch the Instance
-	harbor := &registriesv1alpha1.Instance{}
-	ns := types.NamespacedName{
-		Namespace: repository.Namespace,
-		Name:      repository.Spec.ParentInstance.Name,
-	}
-	err = r.client.Get(ctx, ns, harbor)
-	if errors.IsNotFound(err) {
-		repository.Status = registriesv1alpha1.RepositoryStatus{
-			Name:           string(registriesv1alpha1.RepositoryStatusPhaseCreating),
-			Message:        "corresponding harbor instance does not exist",
-			LastTransition: &now,
+	harbor, err := internal.FetchReadyHarborInstance(ctx, repository.Namespace, repository.Spec.ParentInstance.Name, r.client)
+	if err != nil {
+		if err == internal.ErrInstanceNotFound {
+			repository.Status = registriesv1alpha1.RepositoryStatus{Name: string(registriesv1alpha1.RepositoryStatusPhaseCreating)}
+			// Requeue, the instance might not have been created yet
+			return reconcile.Result{RequeueAfter: time.Second * 30}, nil
+		} else if err == internal.ErrInstanceNotReady {
+			return reconcile.Result{RequeueAfter: 120 * time.Second}, err
+		} else {
+			repository.Status = registriesv1alpha1.RepositoryStatus{LastTransition: &now}
 		}
 		res, err := r.patchRepository(ctx, originalRepository, repository)
 		if err != nil {
 			return res, err
 		}
-		// Requeue, Instance might not have been created yet
-		return reconcile.Result{RequeueAfter: time.Second * 30}, nil
-	} else if err != nil {
-		repository.Status = registriesv1alpha1.RepositoryStatus{
-			Name:           string(registriesv1alpha1.RepositoryStatusPhaseUnknown),
-			Message:        "could not get existing harbor instance",
-			LastTransition: &now,
-		}
-		return r.patchRepository(ctx, originalRepository, repository)
-	}
-
-	// Reconcile only if the corresponding harbor instance is in 'Ready' state
-	if harbor.Status.Phase.Name != registriesv1alpha1.InstanceStatusPhaseReady {
-		return reconcile.Result{RequeueAfter: 120 * time.Second}, fmt.Errorf("parent instance %s/%s is not ready", harbor.Namespace, harbor.Name)
 	}
 
 	// Build a client to connect to the harbor API

--- a/pkg/controller/repository/repository_controller.go
+++ b/pkg/controller/repository/repository_controller.go
@@ -110,11 +110,11 @@ func (r *ReconcileRepository) Reconcile(request reconcile.Request) (reconcile.Re
 	// Fetch the Instance
 	harbor, err := internal.FetchReadyHarborInstance(ctx, repository.Namespace, repository.Spec.ParentInstance.Name, r.client)
 	if err != nil {
-		if err == internal.ErrInstanceNotFound {
+		if err == internal.ErrInstanceNotFound(repository.Spec.ParentInstance.Name) {
 			repository.Status = registriesv1alpha1.RepositoryStatus{Name: string(registriesv1alpha1.RepositoryStatusPhaseCreating)}
 			// Requeue, the instance might not have been created yet
-			return reconcile.Result{RequeueAfter: time.Second * 30}, nil
-		} else if err == internal.ErrInstanceNotReady {
+			return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+		} else if err == internal.ErrInstanceNotReady(repository.Spec.ParentInstance.Name) {
 			return reconcile.Result{RequeueAfter: 120 * time.Second}, err
 		} else {
 			repository.Status = registriesv1alpha1.RepositoryStatus{LastTransition: &now}

--- a/pkg/controller/repository/repository_controller.go
+++ b/pkg/controller/repository/repository_controller.go
@@ -110,11 +110,11 @@ func (r *ReconcileRepository) Reconcile(request reconcile.Request) (reconcile.Re
 	// Fetch the Instance
 	harbor, err := internal.FetchReadyHarborInstance(ctx, repository.Namespace, repository.Spec.ParentInstance.Name, r.client)
 	if err != nil {
-		if err == internal.ErrInstanceNotFound(repository.Spec.ParentInstance.Name) {
+		if _, ok := err.(internal.ErrInstanceNotFound); ok {
 			repository.Status = registriesv1alpha1.RepositoryStatus{Name: string(registriesv1alpha1.RepositoryStatusPhaseCreating)}
 			// Requeue, the instance might not have been created yet
 			return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
-		} else if err == internal.ErrInstanceNotReady(repository.Spec.ParentInstance.Name) {
+		} else if _, ok := err.(internal.ErrInstanceNotReady); ok {
 			return reconcile.Result{RequeueAfter: 120 * time.Second}, err
 		} else {
 			repository.Status = registriesv1alpha1.RepositoryStatus{LastTransition: &now}

--- a/pkg/controller/user/user_controller.go
+++ b/pkg/controller/user/user_controller.go
@@ -116,11 +116,11 @@ func (r *ReconcileUser) Reconcile(request reconcile.Request) (reconcile.Result, 
 	// Fetch the Instance
 	harbor, err := internal.FetchReadyHarborInstance(ctx, user.Namespace, user.Spec.ParentInstance.Name, r.client)
 	if err != nil {
-		if err == internal.ErrInstanceNotFound(user.Spec.ParentInstance.Name) {
+		if _, ok := err.(internal.ErrInstanceNotFound); ok {
 			user.Status = registriesv1alpha1.UserStatus{Name: string(registriesv1alpha1.UserStatusPhaseCreating)}
 			// Requeue, the instance might not have been created yet
 			return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
-		} else if err == internal.ErrInstanceNotReady(user.Spec.ParentInstance.Name) {
+		} else if _, ok := err.(internal.ErrInstanceNotReady); ok {
 			return reconcile.Result{RequeueAfter: 120 * time.Second}, err
 		} else {
 			user.Status = registriesv1alpha1.UserStatus{LastTransition: &now}

--- a/pkg/controller/user/user_controller.go
+++ b/pkg/controller/user/user_controller.go
@@ -116,11 +116,11 @@ func (r *ReconcileUser) Reconcile(request reconcile.Request) (reconcile.Result, 
 	// Fetch the Instance
 	harbor, err := internal.FetchReadyHarborInstance(ctx, user.Namespace, user.Spec.ParentInstance.Name, r.client)
 	if err != nil {
-		if err == internal.ErrInstanceNotFound {
+		if err == internal.ErrInstanceNotFound(user.Spec.ParentInstance.Name) {
 			user.Status = registriesv1alpha1.UserStatus{Name: string(registriesv1alpha1.UserStatusPhaseCreating)}
 			// Requeue, the instance might not have been created yet
-			return reconcile.Result{RequeueAfter: time.Second * 30}, nil
-		} else if err == internal.ErrInstanceNotReady {
+			return reconcile.Result{RequeueAfter: 30 * time.Second}, nil
+		} else if err == internal.ErrInstanceNotReady(user.Spec.ParentInstance.Name) {
 			return reconcile.Result{RequeueAfter: 120 * time.Second}, err
 		} else {
 			user.Status = registriesv1alpha1.UserStatus{LastTransition: &now}

--- a/pkg/controller/user/user_controller_test.go
+++ b/pkg/controller/user/user_controller_test.go
@@ -93,9 +93,16 @@ func TestUserController_Transition_Creating(t *testing.T) {
 }
 
 func TestUserController_Empty_User_Spec(t *testing.T) {
+	ns := "test-namespace"
+
+	instance := testingregistriesv1alpha1.CreateInstance("test-instance", ns)
+	instance.Status.Phase.Name = registriesv1alpha1.InstanceStatusPhaseReady
+
+	instanceSecret := testingregistriesv1alpha1.CreateSecret(instance.Name+"-harbor-core", ns)
+
 	u := registriesv1alpha1.User{}
 
-	r := buildReconcileWithFakeClientWithMocks([]runtime.Object{&u})
+	r := buildReconcileWithFakeClientWithMocks([]runtime.Object{&u, &instance, &instanceSecret})
 
 	req := reconcile.Request{
 		NamespacedName: types.NamespacedName{


### PR DESCRIPTION
Refactor fetching the parent instance in all controller loops that need the API client to work.
This is done through the newly introduced `FetchReadyHarborInstance`-function.

Also in this PR:
- fix the `Empty_User_Spec` test, which never fulfilled its purpose due to a missing mocked instance
- add build/coverage/maintainability badges to the main README