### PR TITLE
Add code generation to Github workflow

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -35,6 +35,31 @@ jobs:
       - name: Run golangci-lint
         run: $(go env GOPATH)/bin/golangci-lint run -v --timeout 10m
 
+  verify:
+    name: Verify Codegen
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Go 1.13
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.13
+        id: go
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Install operator-sdk
+        run: sudo curl -L -o /usr/local/bin/operator-sdk "https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu" && sudo chmod +x /usr/local/bin/operator-sdk
+
+      - name: Run code generation
+        run: operator-sdk generate k8s && operator-sdk generate crds
+
+      - name: Test diff
+        run: |
+          git diff | cat
+          git status --porcelain=v1
+          test $(git status --porcelain=v1 | wc -l) -eq 0
+
   test:
     name: Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
- Add a job to the Github actions that runs `operator-sdk generate` commands to validate code generation