### PR TITLE
Fix: use correct custom-resource names

### DIFF
--- a/deploy/helm-chart/harbor-operator/templates/instance/user.yaml
+++ b/deploy/helm-chart/harbor-operator/templates/instance/user.yaml
@@ -12,7 +12,7 @@ data:
 apiVersion: registries.mittwald.de/v1alpha1
 kind: User
 metadata:
-  name: {{ $user.name }}
+  name: {{ $instance.name }}-{{ $user.name }}
   labels:
     {{- include "chart.labels" $ | nindent 4 }}
 spec:

--- a/pkg/controller/repository/repository_controller.go
+++ b/pkg/controller/repository/repository_controller.go
@@ -209,7 +209,7 @@ func (r *ReconcileRepository) patchRepository(ctx context.Context, originalRepos
 
 // assertDeletedRepository deletes a Harbor project, first ensuring its existence
 func (r *ReconcileRepository) assertDeletedRepository(log logr.Logger, harborClient *h.Client, repository *registriesv1alpha1.Repository) error {
-	opt := h.ListProjectsOptions{Name: repository.Name}
+	opt := h.ListProjectsOptions{Name: repository.Spec.Name}
 	repos, err := harborClient.Projects().ListProjects(opt)
 	if err != nil {
 		return err
@@ -232,7 +232,7 @@ func (r *ReconcileRepository) assertDeletedRepository(log logr.Logger, harborCli
 // Check harbor projects and their components for their existence,
 // create and delete either of those to match the specification
 func (r *ReconcileRepository) assertExistingRepository(harborClient *h.Client, repository *registriesv1alpha1.Repository) error {
-	opt := h.ListProjectsOptions{Name: repository.Name}
+	opt := h.ListProjectsOptions{Name: repository.Spec.Name}
 	heldRepos, err := harborClient.Projects().ListProjects(opt)
 	if err != nil {
 		return err
@@ -247,7 +247,7 @@ func (r *ReconcileRepository) assertExistingRepository(harborClient *h.Client, r
 		}
 
 		pReq := h.ProjectRequest{
-			Name:     repository.Name,
+			Name:     repository.Spec.Name,
 			Metadata: newRepositoryMeta,
 		}
 		return harborClient.Projects().CreateProject(pReq)

--- a/pkg/controller/user/user_controller.go
+++ b/pkg/controller/user/user_controller.go
@@ -240,7 +240,7 @@ func (r *ReconcileUser) createUser(harborClient *h.Client, user *registriesv1alp
 func (r *ReconcileUser) labelsForUserSecret(user *registriesv1alpha1.User, instanceName string) map[string]string {
 	return map[string]string{
 		labelUserRegistry:  instanceName,
-		labelUserComponent: user.Name + "-secret",
+		labelUserComponent: user.Spec.Name + "-secret",
 		labelUserRelease:   "harbor",
 	}
 }


### PR DESCRIPTION
- use `repository.Spec.Name` instead of `repository.Name` for repositories
- prepend instance-name to users