### PR TITLE
fix generating/retrieving user-secret

### DIFF
--- a/pkg/controller/user/secret.go
+++ b/pkg/controller/user/secret.go
@@ -2,6 +2,7 @@ package user
 
 import (
 	"context"
+
 	registriesv1alpha1 "github.com/mittwald/harbor-operator/pkg/apis/registries/v1alpha1"
 	"github.com/mittwald/harbor-operator/pkg/internal/helper"
 	corev1 "k8s.io/api/core/v1"
@@ -12,7 +13,7 @@ import (
 
 func (r *ReconcileUser) getSecretForUser(ctx context.Context, user *registriesv1alpha1.User) (*corev1.Secret, error) {
 	sec := &corev1.Secret{}
-	sec.Name = user.Spec.ParentInstance.Name + "-" + user.Spec.UserSecretRef.Name
+	sec.Name = user.Spec.UserSecretRef.Name
 	sec.Namespace = user.Namespace
 	err := r.client.Get(ctx, types.NamespacedName{Name: sec.Name, Namespace: sec.Namespace}, sec)
 	if err != nil {
@@ -25,7 +26,7 @@ func (r *ReconcileUser) newSecretForUser(ctx context.Context, user *registriesv1
 	ls := r.labelsForUserSecret(user, user.Spec.ParentInstance.Name)
 
 	sec := &corev1.Secret{}
-	sec.Name = user.Spec.ParentInstance.Name + "-" + user.Spec.UserSecretRef.Name
+	sec.Name = user.Spec.UserSecretRef.Name
 	sec.Namespace = user.Namespace
 
 	err := r.client.Get(ctx, types.NamespacedName{Name: sec.Name, Namespace: sec.Namespace}, sec)
@@ -40,7 +41,7 @@ func (r *ReconcileUser) newSecretForUser(ctx context.Context, user *registriesv1
 				APIVersion: "v1",
 			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      user.Spec.ParentInstance.Name + "-" + user.Spec.UserSecretRef.Name,
+				Name:      user.Spec.UserSecretRef.Name,
 				Namespace: user.Namespace,
 				Labels:    ls,
 				OwnerReferences: []metav1.OwnerReference{{
@@ -51,7 +52,7 @@ func (r *ReconcileUser) newSecretForUser(ctx context.Context, user *registriesv1
 				}},
 			},
 			Data: map[string][]byte{
-				"username": []byte(user.Name),
+				"username": []byte(user.Spec.Name),
 				"password": []byte(pw),
 			},
 		}

--- a/pkg/controller/user/user_controller_test.go
+++ b/pkg/controller/user/user_controller_test.go
@@ -2,6 +2,9 @@ package user
 
 import (
 	"context"
+	"testing"
+	"time"
+
 	registriesv1alpha1 "github.com/mittwald/harbor-operator/pkg/apis/registries/v1alpha1"
 	testingregistriesv1alpha1 "github.com/mittwald/harbor-operator/pkg/testing/registriesv1alpha1"
 	corev1 "k8s.io/api/core/v1"
@@ -10,8 +13,6 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"testing"
-	"time"
 )
 
 // buildReconcileWithFakeClientWithMocks
@@ -387,11 +388,11 @@ func TestUserController_User_Create_Secret(t *testing.T) {
 
 	user := testingregistriesv1alpha1.CreateUser("test-user", ns)
 	user.Spec.ParentInstance.Name = instance.Spec.Name
-	user.Spec.UserSecretRef.Name = "test-secret"
+	user.Spec.UserSecretRef.Name = instanceSecret.Name
 	user.Status.Phase = registriesv1alpha1.UserStatusPhaseCreating
 
 	userSecret := corev1.Secret{}
-	userSecret.Name = user.Spec.ParentInstance.Name + "-" + user.Spec.UserSecretRef.Name
+	userSecret.Name = user.Spec.UserSecretRef.Name
 	userSecret.Namespace = user.Namespace
 
 	r := buildReconcileWithFakeClientWithMocks([]runtime.Object{&user, &instance, &instanceSecret})


### PR DESCRIPTION
a reference name should refer directly to the target and not just be part of the actual name