### PR TITLE
More unit tests for instance and instancechartrepo controllers

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -73,9 +73,6 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      - name: Create kind cluster
-        run: make kind
-
       - name: Hack Code Climate and Go Modules
         if: github.event_name != 'pull_request'
         run: mkdir -p github.com/mittwald && ln -sf $(pwd) github.com/mittwald/harbor-operator

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ uninstall: ## Uninstall all installations performed in the $ make install
 	kubectl delete -f deploy/operator.yaml -n ${NAMESPACE}
 
 .PHONY: test
-test: kind
+test:
 	@echo go test
 	go test ./... -v
 
@@ -30,11 +30,6 @@ test: kind
 fmt:
 	@echo go fmt
 	go fmt $$(go list ./...)
-
-.PHONY: kind
-kind: ## Create a kind cluster to test against
-	kind create cluster --name kind-harbor-operator
-	kind get kubeconfig --internal --name kind-harbor-operator | tee ${KUBECONFIG}
 
 .PHONY: build
 build:

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/fatih/color v1.9.0 // indirect
 	github.com/go-logr/logr v0.1.0
+	github.com/golang/mock v1.4.3
 	github.com/imdario/mergo v0.3.8
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/json-iterator/go v1.1.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -369,6 +369,7 @@ github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.3.1 h1:qGJ6qTW+x6xX/my+8YUVl4WNpX9B7+/l2tRsHGZ7f2s=
 github.com/golang/mock v1.3.1/go.mod h1:sBzyDLLjw3U8JLTeZvSv8jJB+tU5PVekmnlKIyFUx0Y=
+github.com/golang/mock v1.4.3 h1:GV+pQPG/EUUbkh47niozDcADz6go/dUwhVzdUQHIVRw=
 github.com/golang/mock v1.4.3/go.mod h1:UOMv5ysSaYNkG+OFQykRIcU/QvvxJf3p21QfJ2Bt3cw=
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.0.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/pkg/controller/instance/instance_controller_test.go
+++ b/pkg/controller/instance/instance_controller_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
+	helmclient "github.com/mittwald/go-helm-client"
+	helmclientmock "github.com/mittwald/go-helm-client/mock"
 	registriesv1alpha1 "github.com/mittwald/harbor-operator/pkg/apis/registries/v1alpha1"
 	testingregistriesv1alpha1 "github.com/mittwald/harbor-operator/pkg/testing/registriesv1alpha1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -173,45 +176,104 @@ func TestInstanceController_Transition_Installing(t *testing.T) {
 	}
 }
 
-// TestInstanceController_Instance_Deletion
-// Test the deletion of an instance object
-func TestInstanceController_Instance_Deletion(t *testing.T) {
-	ns := "test-namespace"
-
-	i := testingregistriesv1alpha1.CreateInstance("test-instance", ns)
-
-	instanceSecret := testingregistriesv1alpha1.CreateSecret(i.Name+"-harbor-core", ns)
-	i.Status.Phase.Name = registriesv1alpha1.InstanceStatusPhaseReady
-
-	r := buildReconcileWithFakeClientWithMocks([]runtime.Object{&i, &instanceSecret})
-
+// TestInstanceController_Istance_Installation
+// Test if an instance object triggers the installation of an helm chart.
+func TestInstanceController_Istance_Installation(t *testing.T) {
+	i := testingregistriesv1alpha1.CreateInstance("harbor", "foobar")
+	i.Status.Phase.Name = registriesv1alpha1.InstanceStatusPhaseInstalling
 	i.DeletionTimestamp = &metav1.Time{Time: time.Now()}
 
-	req := reconcile.Request{
-		NamespacedName: types.NamespacedName{
-			Name:      i.Name,
-			Namespace: i.Namespace,
-		},
+	chartSecret := testingregistriesv1alpha1.CreateSecret(i.Name+"-harbor-core", "foobar")
+	r := buildReconcileWithFakeClientWithMocks([]runtime.Object{&i, &chartSecret})
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := helmclientmock.NewMockClient(ctrl)
+	gomock.InOrder(
+		mockClient.EXPECT().UpdateChartRepos(),
+		mockClient.EXPECT().InstallOrUpgradeChart(&helmclient.ChartSpec{
+			ReleaseName: i.Spec.HelmChart.ReleaseName,
+			ChartName:   i.Spec.HelmChart.ChartName,
+			Namespace:   i.Spec.HelmChart.Namespace,
+			ValuesYaml:  i.Spec.HelmChart.ValuesYaml,
+			Version:     i.Spec.HelmChart.Version,
+		}),
+	)
+	r.helmClientReceiver = func(repoCache, repoConfig, namespace string) (helmclient.Client, error) {
+		return helmclient.Client(mockClient), nil
 	}
 
-	err := r.client.Delete(context.TODO(), &i)
-	if err != nil {
-		t.Error("could not delete instance")
-	}
-
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: i.Name, Namespace: i.Namespace}}
 	res, err := r.Reconcile(req)
+
 	if err != nil {
-		t.Fatalf("reconcile returned error: (%v)", err)
+		t.Fatalf("reconcile returned error: %v", err)
+	}
+	if !res.Requeue {
+		t.Errorf("object got requeued, but should have not")
 	}
 
-	if res.Requeue {
-		t.Error("reconciliation was erroneously requeued")
+	fetched := &registriesv1alpha1.Instance{}
+	err = r.client.Get(context.TODO(), req.NamespacedName, fetched)
+	if err != nil {
+		t.Fatalf("could not get instance: %v", err)
 	}
 
-	instance := &registriesv1alpha1.Instance{}
-	err = r.client.Get(context.TODO(), req.NamespacedName, instance)
-	if err == nil {
-		t.Error("instance was not deleted")
+	if fetched.Status.Phase.Name != registriesv1alpha1.InstanceStatusPhaseReady {
+		t.Errorf("wrong phase of received instance, want: %s, got: %s",
+			registriesv1alpha1.InstanceStatusPhaseReady, i.Status.Phase.Name)
+	}
+	if fetched.Status.Version != i.Spec.Version {
+		t.Errorf("wrong status.version of received instance, want: %s, got: %s",
+			i.Spec.Version, fetched.Status.Version)
+	}
+}
+
+// TestInstanceController_Instance_Deletion
+// Test the deletion of an instance object.
+// Expect the helm chart to be deleted and no finalizers on the object anymore,
+// so Kubernetes would be able to delete the object.
+func TestInstanceController_Instance_Deletion(t *testing.T) {
+	i := testingregistriesv1alpha1.CreateInstance("harbor", "foobar")
+	i.Status.Phase.Name = registriesv1alpha1.InstanceStatusPhaseTerminating
+	i.SetFinalizers([]string{"harbor-operator.registries.mittwald.de"})
+	i.DeletionTimestamp = &metav1.Time{Time: time.Now()}
+
+	r := buildReconcileWithFakeClientWithMocks([]runtime.Object{&i})
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := helmclientmock.NewMockClient(ctrl)
+	mockClient.EXPECT().UninstallRelease(&helmclient.ChartSpec{
+		ReleaseName: i.Spec.HelmChart.ReleaseName,
+		ChartName:   i.Spec.HelmChart.ChartName,
+		Namespace:   i.Spec.HelmChart.Namespace,
+		ValuesYaml:  i.Spec.HelmChart.ValuesYaml,
+		Version:     i.Spec.HelmChart.Version,
+	})
+	r.helmClientReceiver = func(repoCache, repoConfig, namespace string) (helmclient.Client, error) {
+		return helmclient.Client(mockClient), nil
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{Name: i.Name, Namespace: i.Namespace}}
+	res, err := r.Reconcile(req)
+
+	if err != nil {
+		t.Fatalf("reconcile returned error: %v", err)
+	}
+
+	if !res.Requeue {
+		t.Error("object should have been requeued")
+	}
+
+	fetched := &registriesv1alpha1.Instance{}
+	err = r.client.Get(context.TODO(), req.NamespacedName, fetched)
+	if err != nil {
+		t.Fatalf("could not get instance: %v", err)
+	}
+
+	if len(fetched.GetFinalizers()) != 0 {
+		t.Errorf("Unexpected length of finalizers, expected: %d, got: %d", 0, len(fetched.GetFinalizers()))
 	}
 }
 

--- a/pkg/controller/instancechartrepo/instancechartrepo_controller_test.go
+++ b/pkg/controller/instancechartrepo/instancechartrepo_controller_test.go
@@ -1,0 +1,344 @@
+package instancechartrepo
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	helmclient "github.com/mittwald/go-helm-client"
+	helmclientmock "github.com/mittwald/go-helm-client/mock"
+	registriesv1alpha1 "github.com/mittwald/harbor-operator/pkg/apis/registries/v1alpha1"
+	testingregistriesv1alpha1 "github.com/mittwald/harbor-operator/pkg/testing/registriesv1alpha1"
+	"helm.sh/helm/v3/pkg/repo"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const (
+	testRepoName       = "testrepo"
+	testNamespace      = "default"
+	testSecretName     = "testsecret"
+	testURL            = "http://foo.bar"
+	testError          = "testerror"
+	testSecretUsername = "testuser"
+	testSecretPassword = "testpass"
+	testSecretCertFile = "testcertfile"
+	testSecretKeyFile  = "testkeyfile"
+	testSecretCaFile   = "testcafile"
+)
+
+// newTestReconciler returns a reconcile with fake client, schemes and mock objects
+func newTestReconciler(objs []runtime.Object) *ReconcileInstanceChartRepo {
+	s := scheme.Scheme
+
+	s.AddKnownTypes(
+		registriesv1alpha1.SchemeGroupVersion,
+		&registriesv1alpha1.Instance{},
+		&registriesv1alpha1.InstanceChartRepo{},
+	)
+
+	// create a fake client to mock API calls with the mock objects
+	cl := fake.NewFakeClientWithScheme(s, objs...)
+
+	// create a ReconcileInstance object with the scheme and fake client
+	return &ReconcileInstanceChartRepo{client: cl, scheme: s}
+}
+
+// TestReconcileInstanceChartRepo_getSecret
+// tests if a secret object can be retrieved by a given object reference.
+func TestReconcileInstanceChartRepo_getSecret(t *testing.T) {
+	ctx := context.Background()
+	cr := testingregistriesv1alpha1.CreateInstanceChartRepo(testRepoName, testNamespace)
+	crSecret := testingregistriesv1alpha1.CreateSecret(testSecretName, testNamespace)
+	cr.Spec.SecretRef = &corev1.LocalObjectReference{Name: testSecretName}
+	r := newTestReconciler([]runtime.Object{&crSecret})
+
+	secret, err := r.getSecret(ctx, &cr)
+	if err != nil {
+		t.Fatalf("got error while fetching secret: %v", err)
+	}
+
+	if secret == nil {
+		t.Fatalf("secret is nil, expected a value")
+	}
+	if !reflect.DeepEqual(crSecret.ObjectMeta, secret.ObjectMeta) ||
+		!reflect.DeepEqual(crSecret.Data, secret.Data) {
+		t.Error("fetched secret is not equal to input secret")
+	}
+}
+
+// TestReconcileInstanceChartRepo_getSecret_Missing
+// tests if a missing secret returns a proper error.
+func TestReconcileInstanceChartRepo_getSecret_Missing(t *testing.T) {
+	r := newTestReconciler([]runtime.Object{})
+	ctx := context.Background()
+	cr := testingregistriesv1alpha1.CreateInstanceChartRepo(testRepoName, testNamespace)
+	cr.Spec.SecretRef = &corev1.LocalObjectReference{Name: testSecretName}
+
+	secret, err := r.getSecret(ctx, &cr)
+	if err == nil {
+		t.Fatalf("expected error, but got none")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("Expected keyword 'not found' in error message, got: %v", err)
+	}
+	if secret != nil {
+		t.Errorf("secret should be nil")
+	}
+
+}
+
+// TestReconcileInstanceChartRepo_specToRepoEntry
+// tests if a helm repo spec can be generated out of a InstanceChartRepo object.
+func TestReconcileInstanceChartRepo_specToRepoEntry(t *testing.T) {
+	ctx := context.Background()
+	cr := testingregistriesv1alpha1.CreateInstanceChartRepo(testRepoName, testNamespace)
+	cr.Spec.SecretRef = &corev1.LocalObjectReference{Name: testSecretName}
+	cr.Spec.URL = testURL
+	crSecret := testingregistriesv1alpha1.CreateSecret(testSecretName, testNamespace)
+	crSecret.Data["username"] = []byte(testSecretUsername)
+	crSecret.Data["password"] = []byte(testSecretPassword)
+	crSecret.Data["certFile"] = []byte(testSecretCertFile)
+	crSecret.Data["keyFile"] = []byte(testSecretKeyFile)
+	crSecret.Data["caFile"] = []byte(testSecretCaFile)
+
+	r := newTestReconciler([]runtime.Object{&crSecret})
+
+	repo, err := r.specToRepoEntry(ctx, &cr)
+	if err != nil {
+		t.Fatalf("got error: %v", err)
+	}
+
+	if repo == nil {
+		t.Fatal("repo is nil")
+	}
+
+	if repo.Name != testRepoName {
+		t.Errorf("unexpected name, expected: %s, got: %s", testRepoName, repo.Name)
+	}
+	if repo.URL != testURL {
+		t.Errorf("unexpected url, expected: %s, got: %s", testURL, repo.URL)
+	}
+	if repo.Username != testSecretUsername {
+		t.Errorf("unexpected url, expected: %s, got: %s", testSecretUsername, repo.Username)
+	}
+	if repo.Password != testSecretPassword {
+		t.Errorf("unexpected password, expected: %s, got: %s", testSecretPassword, repo.Password)
+	}
+	if repo.CertFile != testSecretCertFile {
+		t.Errorf("unexpected cert file, expected: %s, got: %s", testSecretCertFile, repo.CertFile)
+	}
+	if repo.KeyFile != testSecretKeyFile {
+		t.Errorf("unexpected key file, expected: %s, got: %s", testSecretKeyFile, repo.KeyFile)
+	}
+	if repo.CAFile != testSecretCaFile {
+		t.Errorf("unexpected ca file, expected: %s, got: %s", testSecretCaFile, repo.CAFile)
+	}
+}
+
+// TestReconcileInstanceChartRepo_specToRepoEntry_MissingSecret
+// tests if a proper error is returned while trying to generate a helm repo spec.
+func TestReconcileInstanceChartRepo_specToRepoEntry_MissingSecret(t *testing.T) {
+	ctx := context.Background()
+	cr := testingregistriesv1alpha1.CreateInstanceChartRepo(testRepoName, testNamespace)
+	cr.Spec.SecretRef = &corev1.LocalObjectReference{Name: testSecretName}
+	cr.Spec.URL = testURL
+
+	r := newTestReconciler([]runtime.Object{})
+
+	repo, err := r.specToRepoEntry(ctx, &cr)
+	if err == nil {
+		t.Fatalf("expected error, but got none")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("Expected keyword 'not found' in error message, got: %v", err)
+	}
+	if repo != nil {
+		t.Fatal("repo must be nil")
+	}
+}
+
+// TestReconcileInstanceChartRepo_specToRepoEntry_NilCR
+// tests if a nil InstanceChartRepo is properly handled by specToRepoEntry().
+func TestReconcileInstanceChartRepo_specToRepoEntry_NilCR(t *testing.T) {
+	ctx := context.Background()
+	r := newTestReconciler([]runtime.Object{})
+	repo, err := r.specToRepoEntry(ctx, nil)
+	if err == nil {
+		t.Fatalf("expected error, but got none")
+	}
+	if !strings.Contains(err.Error(), "no instance chart") {
+		t.Errorf("Expected keyword 'not found' in error message, got: %v", err)
+	}
+	if repo != nil {
+		t.Fatal("repo must be nil")
+	}
+}
+
+// TestReconcileInstanceChartRepo_specToRepoEntry_NameOverwrite
+// tests if a cr.Spec.Name overwrites the repochart.Name, when set.
+func TestReconcileInstanceChartRepo_specToRepoEntry_NameOverwrite(t *testing.T) {
+	overwriteName := "something-else"
+	ctx := context.Background()
+	cr := testingregistriesv1alpha1.CreateInstanceChartRepo(testRepoName, testNamespace)
+	cr.Spec.SecretRef = &corev1.LocalObjectReference{Name: testSecretName}
+	cr.Spec.Name = overwriteName
+	cr.Spec.URL = testURL
+	crSecret := testingregistriesv1alpha1.CreateSecret(testSecretName, testNamespace)
+
+	r := newTestReconciler([]runtime.Object{&crSecret})
+
+	repo, err := r.specToRepoEntry(ctx, &cr)
+	if err != nil {
+		t.Fatalf("got error: %v", err)
+	}
+
+	if repo == nil {
+		t.Fatal("repo is nil")
+	}
+
+	if repo.Name != overwriteName {
+		t.Errorf("unexpected name, expected: %s, got: %s", overwriteName, repo.Name)
+	}
+}
+
+// TestReconcileInstanceChartRepo_specToRepoEntry_setErrStatus
+// tests if status and error on a InstanceChartRepo is properly set.
+func TestReconcileInstanceChartRepo_specToRepoEntry_setErrStatus(t *testing.T) {
+	ctx := context.Background()
+	cr := testingregistriesv1alpha1.CreateInstanceChartRepo(testRepoName, testNamespace)
+	cr.Spec.SecretRef = &corev1.LocalObjectReference{Name: testSecretName}
+	cr.Spec.URL = testURL
+	err := errors.New(testError)
+
+	r := newTestReconciler([]runtime.Object{&cr})
+	res, rErr := r.setErrStatus(ctx, &cr, err)
+	if err != rErr {
+		t.Error("received error did not match input error")
+	}
+	if res.Requeue {
+		t.Error("object got requeued, but must not")
+	}
+
+	fetched := &registriesv1alpha1.InstanceChartRepo{}
+	err = r.client.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: testRepoName}, fetched)
+	if err != nil {
+		t.Fatalf("no instance object found in loop")
+	}
+
+	if fetched.Status.State != registriesv1alpha1.RepoStateError {
+		t.Errorf("unexpected state, expected: %s, got: %s", registriesv1alpha1.RepoStateError, fetched.Status.State)
+	}
+}
+
+// TestReconcileInstanceChartRepo_specToRepoEntry_setErrStatus_NotRegistered
+// tests if setErrStatus() can properly handle a object, which is not in the reconcilation loop.
+func TestReconcileInstanceChartRepo_specToRepoEntry_setErrStatus_NotRegistered(t *testing.T) {
+	ctx := context.Background()
+	cr := testingregistriesv1alpha1.CreateInstanceChartRepo(testRepoName, testNamespace)
+	cr.Spec.SecretRef = &corev1.LocalObjectReference{Name: testSecretName}
+	cr.Spec.URL = testURL
+	err := errors.New(testError)
+
+	r := newTestReconciler([]runtime.Object{})
+	_, rErr := r.setErrStatus(ctx, &cr, err)
+	if rErr == nil {
+		t.Fatal("expected error, but got none")
+	}
+	if !strings.Contains(rErr.Error(), "not found") {
+		t.Errorf("Expected keyword 'not found' in error message, got: %v", rErr)
+	}
+}
+
+// TestReconcileInstanceChartRepo_Reconcile
+// tests if a valid InstanceChartRepo in reconcilation loop is properly handled.
+func TestReconcileInstanceChartRepo_Reconcile(t *testing.T) {
+	cr := testingregistriesv1alpha1.CreateInstanceChartRepo(testRepoName, testNamespace)
+	cr.Spec.SecretRef = &corev1.LocalObjectReference{Name: testSecretName}
+	cr.Spec.URL = testURL
+	crSecret := testingregistriesv1alpha1.CreateSecret(testSecretName, testNamespace)
+
+	r := newTestReconciler([]runtime.Object{&cr, &crSecret})
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := helmclientmock.NewMockClient(ctrl)
+	mockClient.EXPECT().AddOrUpdateChartRepo(repo.Entry{
+		Name: testRepoName,
+		URL:  testURL,
+	})
+	r.helmClientReceiver = func(repoCache, repoConfig, namespace string) (helmclient.Client, error) {
+		return helmclient.Client(mockClient), nil
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{
+		Namespace: testNamespace,
+		Name:      testRepoName,
+	}}
+	res, err := r.Reconcile(req)
+	if err != nil {
+		t.Fatalf("error while reconciling: %v", err)
+	}
+	if res.Requeue {
+		t.Error("object got requeued")
+	}
+
+	ctx := context.Background()
+	fetched := &registriesv1alpha1.InstanceChartRepo{}
+	err = r.client.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: testRepoName}, fetched)
+	if err != nil {
+		t.Fatalf("no instance object found in loop")
+	}
+
+	if fetched.Status.State != registriesv1alpha1.RepoStateReady {
+		t.Errorf("unexpected state, expected: %s, got: %s", registriesv1alpha1.RepoStateReady, fetched.Status.State)
+	}
+}
+
+// TestReconcileInstanceChartRepo_Reconcile_MissingSecret
+// tests if the reconciler is able to return a proper error, when a secret to a InstanceChartRepo is missing.
+func TestReconcileInstanceChartRepo_Reconcile_MissingSecret(t *testing.T) {
+	cr := testingregistriesv1alpha1.CreateInstanceChartRepo(testRepoName, testNamespace)
+	cr.Spec.SecretRef = &corev1.LocalObjectReference{Name: testSecretName}
+	cr.Spec.URL = testURL
+
+	r := newTestReconciler([]runtime.Object{&cr})
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockClient := helmclientmock.NewMockClient(ctrl)
+	r.helmClientReceiver = func(repoCache, repoConfig, namespace string) (helmclient.Client, error) {
+		return helmclient.Client(mockClient), nil
+	}
+
+	req := reconcile.Request{NamespacedName: types.NamespacedName{
+		Namespace: testNamespace,
+		Name:      testRepoName,
+	}}
+	res, err := r.Reconcile(req)
+	if err == nil {
+		t.Fatalf("expected error, but got none")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("Expected keyword 'not found' in error message, got: %v", err)
+	}
+	if res.Requeue {
+		t.Error("object got requeued")
+	}
+
+	ctx := context.Background()
+	fetched := &registriesv1alpha1.InstanceChartRepo{}
+	err = r.client.Get(ctx, types.NamespacedName{Namespace: testNamespace, Name: testRepoName}, fetched)
+	if err != nil {
+		t.Fatalf("no instance object found in loop")
+	}
+
+	if fetched.Status.State != registriesv1alpha1.RepoStateError {
+		t.Errorf("unexpected state, expected: %s, got: %s", registriesv1alpha1.RepoStateError, fetched.Status.State)
+	}
+}

--- a/pkg/testing/registriesv1alpha1/instancechartrepo.go
+++ b/pkg/testing/registriesv1alpha1/instancechartrepo.go
@@ -8,10 +8,13 @@ import (
 // CreateInstanceChartRepo returns an instancechartrepo object with sample values
 func CreateInstanceChartRepo(name, namespace string) registriesv1alpha1.InstanceChartRepo {
 	icr := registriesv1alpha1.InstanceChartRepo{
-		TypeMeta:   metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{},
-		Spec:       registriesv1alpha1.InstanceChartRepoSpec{},
-		Status:     registriesv1alpha1.InstanceChartRepoStatus{},
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec:   registriesv1alpha1.InstanceChartRepoSpec{},
+		Status: registriesv1alpha1.InstanceChartRepoStatus{},
 	}
 
 	return icr


### PR DESCRIPTION
Adds missing unit tests on instance controller using a mocked helmclient. Also adding unit tests for instancechartrepo controller. Also removed the code triggering kind cluster generation in Github actions and `Makefile`, because we don't need it at the moment.