### PR TITLE
fix instance controller bug, add unit tests

### DIFF
--- a/.github/workflows/godoc.yml
+++ b/.github/workflows/godoc.yml
@@ -13,4 +13,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Test successful curl against module mirror
-        run : test $(curl -s -o /dev/null -w "%{http_code}"  https://proxy.golang.org/github.com/mittwald/harbor-operator/@v/${GITHUB_REF/refs\/tags\//}.info) -eq 200
+        run : test $(curl -s -o /dev/null -w "%{http_code}"  ${GOPROXY}/github.com/mittwald/harbor-operator/@v/${GITHUB_REF/refs\/tags\//}.info) -eq 200

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/jinzhu/copier v0.0.0-20190924061706-b57f9002281a
 	github.com/json-iterator/go v1.1.8 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
-	github.com/mittwald/go-helm-client v0.1.1
+	github.com/mittwald/go-helm-client v0.2.0
 	github.com/mittwald/goharbor-client v0.1.1
 	github.com/operator-framework/operator-sdk v0.16.0
 	github.com/parnurzeal/gorequest v0.2.16 // indirect

--- a/go.sum
+++ b/go.sum
@@ -586,6 +586,8 @@ github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/I
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mittwald/go-helm-client v0.1.1 h1:A1Jvo81y90dF6B+daRAe0gNJPHnUcr9lPKmYkSjj6OM=
 github.com/mittwald/go-helm-client v0.1.1/go.mod h1:I7ckTZWf4GSsaz399Hku6iG6wA9TdTvQM40T8TnlN28=
+github.com/mittwald/go-helm-client v0.2.0 h1:SncUYLC+g2aTho6IPPMT0ICSXsi1sSUC4rzUFa90vlk=
+github.com/mittwald/go-helm-client v0.2.0/go.mod h1:I7ckTZWf4GSsaz399Hku6iG6wA9TdTvQM40T8TnlN28=
 github.com/mittwald/goharbor-client v0.1.1 h1:wTJwC+cC2EEKjV08nHHFQZAnzfa+5Nxjb6qCJmfEaJI=
 github.com/mittwald/goharbor-client v0.1.1/go.mod h1:OZd5dfBZmqIeGJU2b8Y977zBfjnyq/ZDDQE/FRAlnQg=
 github.com/moby/moby v0.7.3-0.20190826074503-38ab9da00309 h1:cvy4lBOYN3gKfKj8Lzz5Q9TfviP+L7koMHY7SvkyTKs=

--- a/pkg/apis/registries/v1alpha1/member_role.go
+++ b/pkg/apis/registries/v1alpha1/member_role.go
@@ -1,6 +1,5 @@
 package v1alpha1
 
-
 // ID returns a role ID integer by enumerating the given role
 func (role MemberRole) ID() int {
 	switch role {

--- a/pkg/internal/helper/hash.go
+++ b/pkg/internal/helper/hash.go
@@ -4,6 +4,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	helmclient "github.com/mittwald/go-helm-client"
 )
 
 type InterfaceHash []byte
@@ -38,4 +39,20 @@ func GenerateHashFromInterfaces(interfaces []interface{}) (InterfaceHash, error)
 	}
 
 	return hash.Sum(nil), nil
+}
+
+// CreateSpecHash returns a hash string constructed with the helm chart spec
+func CreateSpecHash(spec *helmclient.ChartSpec) (string, error) {
+	hashSrc, err := json.Marshal(spec)
+	if err != nil {
+		return "", err
+	}
+
+	toHash := []interface{}{hashSrc}
+	hash, err := GenerateHashFromInterfaces(toHash)
+	if err != nil {
+		return "", err
+	}
+
+	return hash.String(), nil
 }


### PR DESCRIPTION
- fix a bug in the instance controller, where helm installations would always be executed twice, due to a missing spec hash value
- add unit tests for the instance controller
- move createSpecHash function from controller pkg to helper pkg