### PR TITLE
Some fixes for user, replication and repository handling

### DIFF
--- a/deploy/helm-chart/harbor-operator/crds/registries.mittwald.de_replications_crd.yaml
+++ b/deploy/helm-chart/harbor-operator/crds/registries.mittwald.de_replications_crd.yaml
@@ -117,9 +117,10 @@ spec:
                   description: TriggerType represents the type of trigger.
                   type: string
               required:
-              - triggerSettings
               - type
               type: object
+            triggerAfterCreation:
+              type: boolean
           required:
           - deletion
           - id

--- a/deploy/helm-chart/harbor-operator/crds/registries.mittwald.de_users_crd.yaml
+++ b/deploy/helm-chart/harbor-operator/crds/registries.mittwald.de_users_crd.yaml
@@ -83,11 +83,14 @@ spec:
               type: string
             name:
               type: string
+            passwordHash:
+              type: string
             phase:
               type: string
           required:
           - message
           - name
+          - passwordHash
           - phase
           type: object
       type: object

--- a/deploy/helm-chart/harbor-operator/crds/registries.mittwald.de_users_crd.yaml
+++ b/deploy/helm-chart/harbor-operator/crds/registries.mittwald.de_users_crd.yaml
@@ -3,6 +3,11 @@ kind: CustomResourceDefinition
 metadata:
   name: users.registries.mittwald.de
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: phase
+    name: Status
+    type: string
   group: registries.mittwald.de
   names:
     kind: User

--- a/deploy/helm-chart/harbor-operator/templates/instance/replication.yaml
+++ b/deploy/helm-chart/harbor-operator/templates/instance/replication.yaml
@@ -13,6 +13,7 @@ spec:
   id: {{ $repl.id }}
   deletion: {{ $repl.deletion }}
   override: {{ $repl.override }}
+  triggerAfterCreation: {{ $repl.triggerAfterCreation }}
 
   {{- if $repl.description }}
   description: {{ $repl.description }}

--- a/deploy/helm-chart/harbor-operator/templates/instance/replication.yaml
+++ b/deploy/helm-chart/harbor-operator/templates/instance/replication.yaml
@@ -27,11 +27,11 @@ spec:
   {{- end }}
 
   {{- if $repl.srcRegistry }}
-  srcRegistry: {{ $repl.srcRegistryName }}
+  srcRegistry: {{ $instance.name }}-{{ $repl.srcRegistryName }}
   {{- end }}
 
   {{- if $repl.destRegistry }}
-  destRegistry: {{ $repl.destRegistryName }}
+  destRegistry: {{ $instance.name }}-{{ $repl.destRegistryName }}
   {{- end }}
 
   {{- if $repl.enabled }}

--- a/deploy/helm-chart/harbor-operator/templates/instance/replication.yaml
+++ b/deploy/helm-chart/harbor-operator/templates/instance/replication.yaml
@@ -28,11 +28,13 @@ spec:
   {{- end }}
 
   {{- if $repl.srcRegistry }}
-  srcRegistry: {{ $instance.name }}-{{ $repl.srcRegistryName }}
+  srcRegistry:
+    name: {{ $instance.name }}-{{ $repl.srcRegistryName }}
   {{- end }}
 
   {{- if $repl.destRegistry }}
-  destRegistry: {{ $instance.name }}-{{ $repl.destRegistryName }}
+  destRegistry:
+    name: {{ $instance.name }}-{{ $repl.destRegistryName }}
   {{- end }}
 
   {{- if $repl.enabled }}

--- a/deploy/helm-chart/harbor-operator/templates/instance/user.yaml
+++ b/deploy/helm-chart/harbor-operator/templates/instance/user.yaml
@@ -3,7 +3,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $instance.name }}-{{ $user.name }}
+  name: {{ $instance.name }}-user-{{ $user.name }}
   labels:
     {{- include "chart.labels" $ | nindent 4 }}
 data:
@@ -19,7 +19,7 @@ spec:
   parentInstance:
     name: {{ $instance.name }}
   userSecretRef:
-    name: {{ $instance.name }}-{{ $user.name }}
+    name: {{ $instance.name }}-user-{{ $user.name }}
   name: {{ $user.name }}
   realname: {{ $user.realname }}
   email: {{ $user.email }}

--- a/examples/README.md
+++ b/examples/README.md
@@ -195,6 +195,7 @@ spec:
   deletion: false
   override: true
   enabled: true
+  triggerAfterCreation: true
   srcRegistry:
     name: test-registry
 #  filters:
@@ -231,6 +232,7 @@ spec:
   deletion: false
   override: true
   enabled: true
+  triggerAfterCreation: true
   destRegistry:
     name: test-registry
 #  filters:

--- a/examples/README.md
+++ b/examples/README.md
@@ -272,7 +272,7 @@ spec:
 #### User Secrets
 A user CR must contain the name of a kubernetes secret (*LocalObjectReference*) specfied via `.spec.userSecretRef.name`.
 
-**Note**: If a pre-existing (or manually created) secret is specified, it is not included for deletion through reconciliation.
+**Note**: If a pre-existing (or manually created) secret is specified, **it is included for deletion** through reconciliation if the user is deleted.
 
 In case the secret with the specified name cannot be found, a new secret with the specified name `.spec.userSecretRef.name` will be created instead.
 The users password will then be randomly generated.

--- a/examples/replication_dst.yaml
+++ b/examples/replication_dst.yaml
@@ -15,6 +15,7 @@ spec:
   deletion: false
   override: true
   enabled: true
+  triggerAfterCreation: true
   destRegistry: # you have to create the destRegistry via a registry custom resource first
     name: test-registry
 #  filters:

--- a/examples/replication_src.yaml
+++ b/examples/replication_src.yaml
@@ -15,6 +15,7 @@ spec:
   deletion: false
   override: true
   enabled: true
+  triggerAfterCreation: true
   srcRegistry: # you have to create the srcRegistry via a registry custom resource first
     name: test-registry
 #  filters:

--- a/examples/user_secret.yaml
+++ b/examples/user_secret.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 data:
-  password: ...
+  password: ... # at least 8 chars, 1 uppercase letter, 1 lowercase letter and 1 number
   username: ...
 kind: Secret
 metadata:

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/json-iterator/go v1.1.8 // indirect
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mittwald/go-helm-client v0.2.0
-	github.com/mittwald/goharbor-client v0.1.3
+	github.com/mittwald/goharbor-client v0.1.4
 	github.com/operator-framework/operator-sdk v0.16.0
 	github.com/parnurzeal/gorequest v0.2.16 // indirect
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -586,8 +586,8 @@ github.com/mitchellh/reflectwalk v1.0.0 h1:9D+8oIskB4VJBN5SFlmc27fSlIBZaov1Wpk/I
 github.com/mitchellh/reflectwalk v1.0.0/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/mittwald/go-helm-client v0.2.0 h1:SncUYLC+g2aTho6IPPMT0ICSXsi1sSUC4rzUFa90vlk=
 github.com/mittwald/go-helm-client v0.2.0/go.mod h1:I7ckTZWf4GSsaz399Hku6iG6wA9TdTvQM40T8TnlN28=
-github.com/mittwald/goharbor-client v0.1.3 h1:+/Kyg1y83NPjkMCjSZsktcuuuEjbE/Oisf3JT+XK/sM=
-github.com/mittwald/goharbor-client v0.1.3/go.mod h1:OZd5dfBZmqIeGJU2b8Y977zBfjnyq/ZDDQE/FRAlnQg=
+github.com/mittwald/goharbor-client v0.1.4 h1:YSHNSYQ9ZbyMrMFBayS4NaKY+9oyVVTsHBOPVRlnWXE=
+github.com/mittwald/goharbor-client v0.1.4/go.mod h1:OZd5dfBZmqIeGJU2b8Y977zBfjnyq/ZDDQE/FRAlnQg=
 github.com/moby/moby v0.7.3-0.20190826074503-38ab9da00309 h1:cvy4lBOYN3gKfKj8Lzz5Q9TfviP+L7koMHY7SvkyTKs=
 github.com/moby/moby v0.7.3-0.20190826074503-38ab9da00309/go.mod h1:fDXVQ6+S340veQPv35CzDahGBmHsiclFwfEygB/TWMc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/pkg/apis/registries/v1alpha1/replication_types.go
+++ b/pkg/apis/registries/v1alpha1/replication_types.go
@@ -67,6 +67,9 @@ type ReplicationSpec struct {
 	// +optional
 	Trigger *Trigger `json:"trigger,omitempty"`
 
+	// +optional
+	TriggerAfterCreation bool `json:"triggerAfterCreation"`
+
 	// The replication policy filter array
 	// +optional
 	Filters []Filter `json:"filters,omitempty"`

--- a/pkg/apis/registries/v1alpha1/replication_types.go
+++ b/pkg/apis/registries/v1alpha1/replication_types.go
@@ -103,8 +103,10 @@ type Filter struct {
 // Have to use our custom type here, because we cannot DeepCopy the pointer of *h.Trigger
 // Trigger holds info for a trigger
 type Trigger struct {
-	Type     TriggerType      `json:"type"`
-	Settings *TriggerSettings `json:"triggerSettings"`
+	Type TriggerType `json:"type"`
+
+	// +optional
+	Settings *TriggerSettings `json:"triggerSettings,omitempty"`
 }
 
 // TriggerSettings holds the settings of a trigger

--- a/pkg/apis/registries/v1alpha1/user_types.go
+++ b/pkg/apis/registries/v1alpha1/user_types.go
@@ -49,9 +49,11 @@ type UserList struct {
 
 // UserStatus defines the state of a single user
 type UserStatus struct {
-	Name    string              `json:"name"`
-	Phase   UserStatusPhaseName `json:"phase"`
-	Message string              `json:"message"`
+	Name         string              `json:"name"`
+	Phase        UserStatusPhaseName `json:"phase"`
+	Message      string              `json:"message"`
+	PasswordHash string              `json:"passwordHash"`
+
 	// Time of last observed transition into this state
 	// +optional
 	LastTransition *metav1.Time `json:"lastTransition,omitempty"`

--- a/pkg/apis/registries/v1alpha1/user_types.go
+++ b/pkg/apis/registries/v1alpha1/user_types.go
@@ -30,12 +30,12 @@ type UserSpec struct {
 // User is the Schema for the users API
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:path=users,scope=Namespaced,shortName=users;harborusers
+// +kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase",description="phase"
 type User struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`
 	Spec              UserSpec `json:"spec,omitempty"`
 
-	//+kubebuilder:printcolumn:name="Status",type="string",JSONPath=".status.phase",description="phase"
 	Status UserStatus `json:"status,omitempty"`
 }
 

--- a/pkg/controller/instance/instance_controller.go
+++ b/pkg/controller/instance/instance_controller.go
@@ -116,15 +116,12 @@ func (r *ReconcileInstance) Reconcile(request reconcile.Request) (reconcile.Resu
 	originalInstance := harbor.DeepCopy()
 
 	if harbor.DeletionTimestamp != nil && harbor.Status.Phase.Name != registriesv1alpha1.InstanceStatusPhaseTerminating {
-		patch := client.MergeFrom(originalInstance)
 		now := metav1.Now()
 		harbor.Status.Phase = registriesv1alpha1.InstanceStatusPhase{
 			Name:           registriesv1alpha1.InstanceStatusPhaseTerminating,
 			Message:        "Deleted",
 			LastTransition: &now}
-		if err := r.client.Patch(ctx, harbor, patch); err != nil {
-			return reconcile.Result{}, err
-		}
+		return r.patchInstance(ctx, originalInstance, harbor)
 	}
 
 	switch harbor.Status.Phase.Name {

--- a/pkg/controller/instance/instance_controller_test.go
+++ b/pkg/controller/instance/instance_controller_test.go
@@ -313,6 +313,13 @@ func TestInstanceController_Instance_Ready_Deletion(t *testing.T) {
 		t.Errorf("instance status unexpected: %s, expected: %s", fetched.Status.Phase.Name, registriesv1alpha1.InstanceStatusPhaseTerminating)
 	}
 
+	res, err = r.Reconcile(req)
+	if err != nil {
+		t.Fatalf("reconcile returned error: (%v)", err)
+	}
+	if !res.Requeue {
+		t.Error("reconciliation was not requeued")
+	}
 }
 
 // TestInstanceController_Instance_Ready_Ensure_Chart_Spec tests the integrity of the helm chart spec

--- a/pkg/controller/instance/instance_controller_test.go
+++ b/pkg/controller/instance/instance_controller_test.go
@@ -313,6 +313,8 @@ func TestInstanceController_Instance_Ready_Deletion(t *testing.T) {
 		t.Errorf("instance status unexpected: %s, expected: %s", fetched.Status.Phase.Name, registriesv1alpha1.InstanceStatusPhaseTerminating)
 	}
 
+	// Reconcile again here to run the steps in the `InstanceStatusPhaseTerminating` phase.
+	// The prior reconcile-step only sets the phase to `InstanceStatusPhaseTerminating` but returns after that.
 	res, err = r.Reconcile(req)
 	if err != nil {
 		t.Fatalf("reconcile returned error: (%v)", err)

--- a/pkg/controller/registry/registry_controller.go
+++ b/pkg/controller/registry/registry_controller.go
@@ -261,8 +261,7 @@ func (r *ReconcileRegistry) buildRegistryFromSpec(originalRegistry *registriesv1
 		tokenServiceURL = parsedTokenServiceURL
 	}
 
-	return h.Registry{
-		ID:              originalRegistry.Spec.ID,
+	registry := h.Registry{
 		Name:            originalRegistry.Spec.Name,
 		Description:     originalRegistry.Spec.Description,
 		Type:            originalRegistry.Spec.Type,
@@ -270,7 +269,12 @@ func (r *ReconcileRegistry) buildRegistryFromSpec(originalRegistry *registriesv1
 		TokenServiceURL: tokenServiceURL,
 		Credential:      originalRegistry.Spec.Credential,
 		Insecure:        originalRegistry.Spec.Insecure,
-	}, nil
+	}
+
+	if originalRegistry.Spec.ID != 0 {
+		registry.ID = originalRegistry.Spec.ID
+	}
+	return registry, nil
 }
 
 // assertDeletedRegistry deletes a registry, first ensuring its existence

--- a/pkg/controller/registry/registry_controller.go
+++ b/pkg/controller/registry/registry_controller.go
@@ -97,7 +97,7 @@ func (r *ReconcileRegistry) Reconcile(request reconcile.Request) (reconcile.Resu
 
 	if registry.ObjectMeta.DeletionTimestamp != nil && registry.Status.Phase != registriesv1alpha1.RegistryStatusPhaseTerminating {
 		registry.Status = registriesv1alpha1.RegistryStatus{Phase: registriesv1alpha1.RegistryStatusPhaseTerminating}
-		r.patchRegistry(ctx, originalRegistry, registry)
+		return r.patchRegistry(ctx, originalRegistry, registry)
 	}
 
 	// Fetch the Instance

--- a/pkg/controller/registry/registry_controller.go
+++ b/pkg/controller/registry/registry_controller.go
@@ -261,7 +261,8 @@ func (r *ReconcileRegistry) buildRegistryFromSpec(originalRegistry *registriesv1
 		tokenServiceURL = parsedTokenServiceURL
 	}
 
-	registry := h.Registry{
+	return h.Registry{
+		ID:              originalRegistry.Spec.ID,
 		Name:            originalRegistry.Spec.Name,
 		Description:     originalRegistry.Spec.Description,
 		Type:            originalRegistry.Spec.Type,
@@ -269,12 +270,7 @@ func (r *ReconcileRegistry) buildRegistryFromSpec(originalRegistry *registriesv1
 		TokenServiceURL: tokenServiceURL,
 		Credential:      originalRegistry.Spec.Credential,
 		Insecure:        originalRegistry.Spec.Insecure,
-	}
-
-	if originalRegistry.Spec.ID != 0 {
-		registry.ID = originalRegistry.Spec.ID
-	}
-	return registry, nil
+	}, nil
 }
 
 // assertDeletedRegistry deletes a registry, first ensuring its existence

--- a/pkg/controller/registry/registry_controller.go
+++ b/pkg/controller/registry/registry_controller.go
@@ -96,11 +96,8 @@ func (r *ReconcileRegistry) Reconcile(request reconcile.Request) (reconcile.Resu
 	originalRegistry := registry.DeepCopy()
 
 	if registry.ObjectMeta.DeletionTimestamp != nil && registry.Status.Phase != registriesv1alpha1.RegistryStatusPhaseTerminating {
-		patch := client.MergeFrom(originalRegistry)
 		registry.Status = registriesv1alpha1.RegistryStatus{Phase: registriesv1alpha1.RegistryStatusPhaseTerminating}
-		if err := r.client.Patch(ctx, registry, patch); err != nil {
-			return reconcile.Result{}, err
-		}
+		r.patchRegistry(ctx, originalRegistry, registry)
 	}
 
 	// Fetch the Instance
@@ -274,7 +271,6 @@ func (r *ReconcileRegistry) buildRegistryFromSpec(originalRegistry *registriesv1
 		Credential:      originalRegistry.Spec.Credential,
 		Insecure:        originalRegistry.Spec.Insecure,
 	}, nil
-
 }
 
 // assertDeletedRegistry deletes a registry, first ensuring its existence

--- a/pkg/controller/replication/replication_controller.go
+++ b/pkg/controller/replication/replication_controller.go
@@ -140,6 +140,16 @@ func (r *ReconcileReplication) Reconcile(request reconcile.Request) (reconcile.R
 		if err != nil {
 			return reconcile.Result{}, err
 		}
+
+		if replication.Spec.TriggerAfterCreation {
+			replExec := h.ReplicationExecution{
+				PolicyID: replication.Spec.ID,
+				Trigger:  "manual",
+			}
+			if err = harborClient.Replications().TriggerReplicationExecution(replExec); err != nil {
+				return reconcile.Result{}, err
+			}
+		}
 		replication.Status = registriesv1alpha1.ReplicationStatus{Phase: registriesv1alpha1.ReplicationStatusPhaseReady}
 
 	case registriesv1alpha1.ReplicationStatusPhaseReady:

--- a/pkg/controller/replication/replication_controller.go
+++ b/pkg/controller/replication/replication_controller.go
@@ -245,9 +245,22 @@ func (r *ReconcileReplication) updateReplication(harborClient *h.Client, rep h.R
 
 // buildReplicationFromSpec returns an API conformed ReplicationPolicy object
 func (r *ReconcileReplication) buildReplicationFromSpec(originalReplication *registriesv1alpha1.Replication) (h.ReplicationPolicy, error) {
-	var hf []*h.Filter
-	hf = append(hf, &h.Filter{})
+	newRep := h.ReplicationPolicy{
+		Name:          originalReplication.Spec.Name,
+		Description:   originalReplication.Spec.Description,
+		Creator:       originalReplication.Spec.Creator,
+		DestNamespace: originalReplication.Spec.DestNamespace,
+		Override:      originalReplication.Spec.Override,
+		Enabled:       originalReplication.Spec.Enabled,
+		Deletion:      originalReplication.Spec.Deletion,
+	}
+
+	if originalReplication.Spec.ID != 0 {
+		newRep.ID = originalReplication.Spec.ID
+	}
+
 	if originalReplication.Spec.Filters != nil {
+		hf := []*h.Filter{}
 		for _, v := range originalReplication.Spec.Filters {
 			err := internal.CheckFilterType(v.Type)
 			if err != nil {
@@ -258,29 +271,21 @@ func (r *ReconcileReplication) buildReplicationFromSpec(originalReplication *reg
 				Value: v.Value,
 			})
 		}
+		newRep.Filters = hf
 	}
 
-	var ht = &h.Trigger{}
 	if originalReplication.Spec.Trigger != nil {
+		ht := &h.Trigger{}
 		validatedType, err := internal.CheckAndGetReplicationTriggerType(originalReplication.Spec.Trigger.Type)
 		if err != nil {
 			return h.ReplicationPolicy{}, err
 		}
-		ht.Type = validatedType
-		ht.Settings = &h.TriggerSettings{Cron: originalReplication.Spec.Trigger.Settings.Cron}
-	}
 
-	newRep := h.ReplicationPolicy{
-		ID:            originalReplication.Spec.ID,
-		Name:          originalReplication.Spec.Name,
-		Description:   originalReplication.Spec.Description,
-		Creator:       originalReplication.Spec.Creator,
-		DestNamespace: originalReplication.Spec.DestNamespace,
-		Override:      originalReplication.Spec.Override,
-		Enabled:       originalReplication.Spec.Enabled,
-		Trigger:       ht,
-		Filters:       hf,
-		Deletion:      originalReplication.Spec.Deletion,
+		ht.Type = validatedType
+		if originalReplication.Spec.Trigger.Settings != nil {
+			ht.Settings = &h.TriggerSettings{Cron: originalReplication.Spec.Trigger.Settings.Cron}
+		}
+		newRep.Trigger = ht
 	}
 
 	if originalReplication.Spec.SrcRegistry != nil && originalReplication.Spec.DestRegistry != nil {

--- a/pkg/controller/replication/replication_controller.go
+++ b/pkg/controller/replication/replication_controller.go
@@ -246,6 +246,7 @@ func (r *ReconcileReplication) updateReplication(harborClient *h.Client, rep h.R
 // buildReplicationFromSpec returns an API conformed ReplicationPolicy object
 func (r *ReconcileReplication) buildReplicationFromSpec(originalReplication *registriesv1alpha1.Replication) (h.ReplicationPolicy, error) {
 	newRep := h.ReplicationPolicy{
+		ID:            originalReplication.Spec.ID,
 		Name:          originalReplication.Spec.Name,
 		Description:   originalReplication.Spec.Description,
 		Creator:       originalReplication.Spec.Creator,
@@ -253,10 +254,6 @@ func (r *ReconcileReplication) buildReplicationFromSpec(originalReplication *reg
 		Override:      originalReplication.Spec.Override,
 		Enabled:       originalReplication.Spec.Enabled,
 		Deletion:      originalReplication.Spec.Deletion,
-	}
-
-	if originalReplication.Spec.ID != 0 {
-		newRep.ID = originalReplication.Spec.ID
 	}
 
 	if originalReplication.Spec.Filters != nil {

--- a/pkg/controller/replication/replication_controller.go
+++ b/pkg/controller/replication/replication_controller.go
@@ -98,11 +98,8 @@ func (r *ReconcileReplication) Reconcile(request reconcile.Request) (reconcile.R
 	originalReplication := replication.DeepCopy()
 
 	if replication.ObjectMeta.DeletionTimestamp != nil && replication.Status.Phase != registriesv1alpha1.ReplicationStatusPhaseTerminating {
-		patch := client.MergeFrom(originalReplication)
 		replication.Status = registriesv1alpha1.ReplicationStatus{Phase: registriesv1alpha1.ReplicationStatusPhaseTerminating}
-		if err := r.client.Patch(ctx, replication, patch); err != nil {
-			return reconcile.Result{}, err
-		}
+		return r.patchReplication(ctx, originalReplication, replication)
 	}
 
 	// Fetch the Instance

--- a/pkg/controller/repository/repository_controller.go
+++ b/pkg/controller/repository/repository_controller.go
@@ -110,11 +110,8 @@ func (r *ReconcileRepository) Reconcile(request reconcile.Request) (reconcile.Re
 	originalRepository := repository.DeepCopy()
 
 	if repository.ObjectMeta.DeletionTimestamp != nil && repository.Status.Phase != registriesv1alpha1.RepositoryStatusPhaseTerminating {
-		patch := client.MergeFrom(originalRepository)
 		repository.Status = registriesv1alpha1.RepositoryStatus{Phase: registriesv1alpha1.RepositoryStatusPhaseTerminating}
-		if err := r.client.Patch(ctx, repository, patch); err != nil {
-			return reconcile.Result{}, err
-		}
+		return r.patchRepository(ctx, originalRepository, repository)
 	}
 
 	// Fetch the Instance

--- a/pkg/controller/user/user_controller.go
+++ b/pkg/controller/user/user_controller.go
@@ -2,7 +2,6 @@ package user
 
 import (
 	"context"
-	"fmt"
 	"reflect"
 	"time"
 
@@ -221,7 +220,6 @@ func (r *ReconcileUser) assertExistingUser(ctx context.Context, harborClient *h.
 	patch := client.MergeFrom(user.DeepCopy())
 	if err == internal.ErrUserNotFound {
 		user.Status.PasswordHash = pwHash.Short()
-		fmt.Println("Password:", pw)
 		if err = r.createUser(harborClient, user, pw); err != nil {
 			return err
 		}


### PR DESCRIPTION
## Replication
- make `triggerSettings` optional.
- add `id`, `filters` and `trigger` only if set in the cr.
- add `triggerAfterCreation` property to replication type.

## User
- change user password only if it has changed.
- display `status.Phase` as column.

## Registry
- only set the registry-id if not 0.

## Common
- if `DeletionTimestamp` is set, set `Phase` to `terminating` and return (instead of "patch-and-continue").

## helm-chart
- add `-user-` to the user-secret name.
- fix replication properties for `src`- and `destRegistry`.