### PR TITLE
Fix/cr owner and others

### DIFF
--- a/deploy/helm-chart/harbor-operator/crds/registries.mittwald.de_replications_crd.yaml
+++ b/deploy/helm-chart/harbor-operator/crds/registries.mittwald.de_replications_crd.yaml
@@ -123,7 +123,6 @@ spec:
               type: boolean
           required:
           - deletion
-          - id
           - name
           - override
           - parentInstance

--- a/deploy/helm-chart/harbor-operator/templates/instance/instance.yaml
+++ b/deploy/helm-chart/harbor-operator/templates/instance/instance.yaml
@@ -19,6 +19,7 @@ spec:
     chart: harbor/harbor
     version: {{ .version }}
     namespace: {{ $.Release.Namespace }}
+    wait: {{ .wait }}
     valuesYaml: |
       {{- with .values }}
       {{- toYaml . | nindent 6 }}

--- a/deploy/helm-chart/harbor-operator/templates/instance/replication.yaml
+++ b/deploy/helm-chart/harbor-operator/templates/instance/replication.yaml
@@ -35,7 +35,7 @@ spec:
     name: {{ $instance.name }}-{{ $repl.srcRegistryName }}
   {{- end }}
 
-  {{- if $repl.srcRegistryName }}
+  {{- if $repl.destRegistryName }}
   destRegistry:
     name: {{ $instance.name }}-{{ $repl.destRegistryName }}
   {{- end }}

--- a/deploy/helm-chart/harbor-operator/templates/instance/replication.yaml
+++ b/deploy/helm-chart/harbor-operator/templates/instance/replication.yaml
@@ -10,10 +10,13 @@ spec:
   parentInstance:
     name: {{ $instance.name }}
   name: {{ $repl.name }}
-  id: {{ $repl.id }}
   deletion: {{ $repl.deletion }}
   override: {{ $repl.override }}
   triggerAfterCreation: {{ $repl.triggerAfterCreation }}
+
+  {{- if $repl.id }}
+  id: {{ $repl.id }}
+  {{- end }}
 
   {{- if $repl.description }}
   description: {{ $repl.description }}

--- a/examples/replication_dst.yaml
+++ b/examples/replication_dst.yaml
@@ -8,7 +8,6 @@ metadata:
   name: test-replication-dst
   namespace: harbor-operator
 spec:
-  id: 2
   name: test-replication-dst
   parentInstance:
     name: test-harbor

--- a/examples/replication_src.yaml
+++ b/examples/replication_src.yaml
@@ -8,7 +8,6 @@ metadata:
   name: test-replication-src
   namespace: harbor-operator
 spec:
-  id: 1
   name: test-replication-src
   parentInstance:
     name: test-harbor

--- a/go.mod
+++ b/go.mod
@@ -25,6 +25,7 @@ require (
 	k8s.io/apimachinery v0.17.2
 	k8s.io/client-go v12.0.0+incompatible
 	k8s.io/kube-openapi v0.0.0-20191107075043-30be4d16710a // indirect
+	k8s.io/kubectl v0.17.2
 	moul.io/http2curl v1.0.0 // indirect
 	sigs.k8s.io/controller-runtime v0.5.2
 )

--- a/pkg/apis/registries/v1alpha1/replication_types.go
+++ b/pkg/apis/registries/v1alpha1/replication_types.go
@@ -29,11 +29,12 @@ const (
 
 // ReplicationSpec defines the desired state of Replication
 type ReplicationSpec struct {
-	ID int64 `json:"id"`
-
 	Name string `json:"name"`
 
 	Deletion bool `json:"deletion"`
+
+	// +optional
+	ID int64 `json:"id"`
 
 	// +optional
 	Description string `json:"description,omitempty"`

--- a/pkg/controller/instance/instance_controller.go
+++ b/pkg/controller/instance/instance_controller.go
@@ -121,7 +121,7 @@ func (r *ReconcileInstance) Reconcile(request reconcile.Request) (reconcile.Resu
 			Name:           registriesv1alpha1.InstanceStatusPhaseTerminating,
 			Message:        "Deleted",
 			LastTransition: &now}
-		return r.patchInstance(ctx, originalInstance, harbor)
+		return r.updateInstanceCR(ctx, originalInstance, harbor)
 	}
 
 	switch harbor.Status.Phase.Name {
@@ -163,7 +163,7 @@ func (r *ReconcileInstance) Reconcile(request reconcile.Request) (reconcile.Resu
 		}
 		if harbor.Status.SpecHash == "" {
 			harbor.Status.SpecHash = specHash
-			return r.patchInstance(ctx, originalInstance, harbor)
+			return r.updateInstanceCR(ctx, originalInstance, harbor)
 		}
 
 	case registriesv1alpha1.InstanceStatusPhaseReady:
@@ -186,7 +186,7 @@ func (r *ReconcileInstance) Reconcile(request reconcile.Request) (reconcile.Resu
 		if harbor.Status.SpecHash != specHash {
 			harbor.Status.Phase.Name = registriesv1alpha1.InstanceStatusPhaseInstalling
 			harbor.Status.SpecHash = specHash
-			return r.patchInstance(ctx, originalInstance, harbor)
+			return r.updateInstanceCR(ctx, originalInstance, harbor)
 		}
 
 	case registriesv1alpha1.InstanceStatusPhaseTerminating:
@@ -196,7 +196,7 @@ func (r *ReconcileInstance) Reconcile(request reconcile.Request) (reconcile.Resu
 		}
 	}
 
-	return r.patchInstance(ctx, originalInstance, harbor)
+	return r.updateInstanceCR(ctx, originalInstance, harbor)
 }
 
 // reconcileTerminatingInstance triggers a helm uninstall for the created release
@@ -223,8 +223,8 @@ func (r *ReconcileInstance) reconcileTerminatingInstance(ctx context.Context, lo
 	return nil
 }
 
-// patchInstance compares the new CR status and finalizers with the pre-existing ones and updates them accordingly
-func (r *ReconcileInstance) patchInstance(ctx context.Context, originalInstance, instance *registriesv1alpha1.Instance) (reconcile.Result, error) {
+// updateInstanceCR compares the new CR status and finalizers with the pre-existing ones and updates them accordingly
+func (r *ReconcileInstance) updateInstanceCR(ctx context.Context, originalInstance, instance *registriesv1alpha1.Instance) (reconcile.Result, error) {
 	// Update Status
 	if !reflect.DeepEqual(originalInstance.Status, instance.Status) {
 		originalInstance.Status = instance.Status

--- a/pkg/controller/instance/instance_controller.go
+++ b/pkg/controller/instance/instance_controller.go
@@ -99,6 +99,8 @@ func (r *ReconcileInstance) Reconcile(request reconcile.Request) (reconcile.Resu
 
 	ctx := context.Background()
 
+	var result reconcile.Result
+
 	// Fetch the Instance
 	harbor := &registriesv1alpha1.Instance{}
 	if err := r.client.Get(ctx, request.NamespacedName, harbor); err != nil {
@@ -121,7 +123,8 @@ func (r *ReconcileInstance) Reconcile(request reconcile.Request) (reconcile.Resu
 			Name:           registriesv1alpha1.InstanceStatusPhaseTerminating,
 			Message:        "Deleted",
 			LastTransition: &now}
-		return r.updateInstanceCR(ctx, originalInstance, harbor)
+		result = reconcile.Result{Requeue: true}
+		return r.updateInstanceCR(ctx, originalInstance, harbor, result)
 	}
 
 	switch harbor.Status.Phase.Name {
@@ -130,6 +133,7 @@ func (r *ReconcileInstance) Reconcile(request reconcile.Request) (reconcile.Resu
 
 	case "":
 		harbor.Status.Phase.Name = registriesv1alpha1.InstanceStatusPhaseInstalling
+		result = reconcile.Result{Requeue: true}
 
 	case registriesv1alpha1.InstanceStatusPhaseInstalling:
 		reqLogger.Info("installing helm-chart")
@@ -161,9 +165,10 @@ func (r *ReconcileInstance) Reconcile(request reconcile.Request) (reconcile.Resu
 		if err != nil {
 			return reconcile.Result{}, err
 		}
+		result = reconcile.Result{Requeue: true}
 		if harbor.Status.SpecHash == "" {
 			harbor.Status.SpecHash = specHash
-			return r.updateInstanceCR(ctx, originalInstance, harbor)
+			return r.updateInstanceCR(ctx, originalInstance, harbor, result)
 		}
 
 	case registriesv1alpha1.InstanceStatusPhaseReady:
@@ -183,10 +188,11 @@ func (r *ReconcileInstance) Reconcile(request reconcile.Request) (reconcile.Resu
 			return reconcile.Result{}, err
 		}
 
+		result = reconcile.Result{}
 		if harbor.Status.SpecHash != specHash {
 			harbor.Status.Phase.Name = registriesv1alpha1.InstanceStatusPhaseInstalling
 			harbor.Status.SpecHash = specHash
-			return r.updateInstanceCR(ctx, originalInstance, harbor)
+			return r.updateInstanceCR(ctx, originalInstance, harbor, result)
 		}
 
 	case registriesv1alpha1.InstanceStatusPhaseTerminating:
@@ -194,9 +200,10 @@ func (r *ReconcileInstance) Reconcile(request reconcile.Request) (reconcile.Resu
 		if err != nil {
 			return reconcile.Result{}, err
 		}
+		result = reconcile.Result{}
 	}
 
-	return r.updateInstanceCR(ctx, originalInstance, harbor)
+	return r.updateInstanceCR(ctx, originalInstance, harbor, result)
 }
 
 // reconcileTerminatingInstance triggers a helm uninstall for the created release
@@ -224,7 +231,7 @@ func (r *ReconcileInstance) reconcileTerminatingInstance(ctx context.Context, lo
 }
 
 // updateInstanceCR compares the new CR status and finalizers with the pre-existing ones and updates them accordingly
-func (r *ReconcileInstance) updateInstanceCR(ctx context.Context, originalInstance, instance *registriesv1alpha1.Instance) (reconcile.Result, error) {
+func (r *ReconcileInstance) updateInstanceCR(ctx context.Context, originalInstance, instance *registriesv1alpha1.Instance, result reconcile.Result) (reconcile.Result, error) {
 	// Update Status
 	if !reflect.DeepEqual(originalInstance.Status, instance.Status) {
 		originalInstance.Status = instance.Status

--- a/pkg/controller/instance/instance_controller.go
+++ b/pkg/controller/instance/instance_controller.go
@@ -232,6 +232,10 @@ func (r *ReconcileInstance) reconcileTerminatingInstance(ctx context.Context, lo
 
 // updateInstanceCR compares the new CR status and finalizers with the pre-existing ones and updates them accordingly
 func (r *ReconcileInstance) updateInstanceCR(ctx context.Context, originalInstance, instance *registriesv1alpha1.Instance, result reconcile.Result) (reconcile.Result, error) {
+	if originalInstance == nil || instance == nil {
+		return reconcile.Result{}, errors.New("cannot update instance cr because (original)instance is nil")
+	}
+
 	// Update Status
 	if !reflect.DeepEqual(originalInstance.Status, instance.Status) {
 		originalInstance.Status = instance.Status

--- a/pkg/controller/internal/harbor_commons.go
+++ b/pkg/controller/internal/harbor_commons.go
@@ -18,12 +18,19 @@ type ErrInstanceNotFound string
 // ErrInstanceNotFound is called when the corresponding Harbor instance is not ready
 type ErrInstanceNotReady string
 
+// ErrRegistryNotReady is called when the corresponding RegistryCR (registriesv1alpha1.Registry) is not ready
+type ErrRegistryNotReady string
+
 func (e ErrInstanceNotFound) Error() string {
 	return fmt.Sprintf("instance '%s' not found", string(e))
 }
 
 func (e ErrInstanceNotReady) Error() string {
 	return fmt.Sprintf("instance '%s' not ready", string(e))
+}
+
+func (e ErrRegistryNotReady) Error() string {
+	return fmt.Sprintf("registry '%s' not ready", string(e))
 }
 
 // ErrUserNotFound is a custom error type describing the absence of a user

--- a/pkg/controller/registry/registry_controller.go
+++ b/pkg/controller/registry/registry_controller.go
@@ -282,12 +282,12 @@ func (r *ReconcileRegistry) buildRegistryFromSpec(originalRegistry *registriesv1
 // assertDeletedRegistry deletes a registry, first ensuring its existence
 func (r *ReconcileRegistry) assertDeletedRegistry(log logr.Logger, harborClient *h.Client, registry *registriesv1alpha1.Registry) error {
 	reg, err := internal.GetRegistry(harborClient, registry)
-	if err != nil {
-		return err
-	}
-
-	err = harborClient.Registries().DeleteRegistryByID(reg.ID)
-	if err != nil {
+	if err == nil {
+		err = harborClient.Registries().DeleteRegistryByID(reg.ID)
+		if err != nil {
+			return err
+		}
+	} else if err != internal.ErrRegistryNotFound {
 		return err
 	}
 

--- a/pkg/controller/registry/registry_controller_test.go
+++ b/pkg/controller/registry/registry_controller_test.go
@@ -78,7 +78,7 @@ func TestRegistryController_Instance_Phase(t *testing.T) {
 		if err == nil {
 			t.Error("reconciliation did not return error as expected")
 		}
-		if res.RequeueAfter != 30*time.Second {
+		if res.RequeueAfter != 30 * time.Second {
 			t.Error("reconciliation did not requeue as expected")
 		}
 	})

--- a/pkg/controller/registry/registry_controller_test.go
+++ b/pkg/controller/registry/registry_controller_test.go
@@ -39,7 +39,7 @@ func buildReconcileWithFakeClientWithMocks(objs []runtime.Object) *ReconcileRegi
 func TestRegistryController_Instance_Phase(t *testing.T) {
 	reg := registriesv1alpha1.Registry{}
 
-	// Test reconciliation with a non existent instance object which is expected to be requeued
+	// Test reconciliation with a non existent instance object
 	// Expect: Result without requeue + no error.
 	t.Run("NonExistentInstance", func(t *testing.T) {
 		r := buildReconcileWithFakeClientWithMocks([]runtime.Object{&reg})
@@ -55,8 +55,8 @@ func TestRegistryController_Instance_Phase(t *testing.T) {
 			t.Fatalf("reconcile returned error: (%v)", err)
 		}
 
-		if res.RequeueAfter != 30*time.Second {
-			t.Error("reconciliation did not requeue as expected")
+		if res.Requeue {
+			t.Error("reconciliation should not be re queued")
 		}
 	})
 
@@ -78,7 +78,7 @@ func TestRegistryController_Instance_Phase(t *testing.T) {
 		if err == nil {
 			t.Error("reconciliation did not return error as expected")
 		}
-		if res.RequeueAfter != 120*time.Second {
+		if res.RequeueAfter != 30*time.Second {
 			t.Error("reconciliation did not requeue as expected")
 		}
 	})

--- a/pkg/controller/replication/replication_controller.go
+++ b/pkg/controller/replication/replication_controller.go
@@ -318,6 +318,10 @@ func (r *ReconcileReplication) getHarborRegistryFromRef(ctx context.Context, reg
 		return nil, err
 	}
 
+	if registry.Status.Phase != registriesv1alpha1.RegistryStatusPhaseReady {
+		return nil, internal.ErrRegistryNotReady(registry.Name)
+	}
+
 	return registry.Spec.ToHarborRegistry(), nil
 }
 

--- a/pkg/controller/replication/replication_controller.go
+++ b/pkg/controller/replication/replication_controller.go
@@ -328,12 +328,12 @@ func (r *ReconcileReplication) getHarborRegistryFromRef(ctx context.Context, reg
 // assertDeletedReplication deletes a replication, first ensuring its existence
 func (r *ReconcileReplication) assertDeletedReplication(log logr.Logger, harborClient *h.Client, replication *registriesv1alpha1.Replication) error {
 	rep, err := internal.GetReplication(harborClient, replication)
-	if err != nil {
-		return err
-	}
-
-	err = harborClient.Replications().DeleteReplicationPolicyByID(rep.ID)
-	if err != nil {
+	if err == nil {
+		err = harborClient.Replications().DeleteReplicationPolicyByID(rep.ID)
+		if err != nil {
+			return err
+		}
+	} else if err != internal.ErrReplicationNotFound {
 		return err
 	}
 

--- a/pkg/controller/replication/replication_controller_test.go
+++ b/pkg/controller/replication/replication_controller_test.go
@@ -37,7 +37,7 @@ func buildReconcileWithFakeClientWithMocks(objs []runtime.Object) *ReconcileRepl
 func TestReplicationController_Instance_Phase(t *testing.T) {
 	rep := registriesv1alpha1.Replication{}
 
-	// Test reconciliation with a non existent instance object which is expected to be requeued
+	// Test reconciliation with a non existent instance object
 	// Expect: Result without requeue + no error.
 	t.Run("NonExistentInstance", func(t *testing.T) {
 		r := buildReconcileWithFakeClientWithMocks([]runtime.Object{&rep})
@@ -53,8 +53,8 @@ func TestReplicationController_Instance_Phase(t *testing.T) {
 			t.Fatalf("reconcile returned error: (%v)", err)
 		}
 
-		if res.RequeueAfter != 30*time.Second {
-			t.Error("reconciliation did not requeue as expected")
+		if res.Requeue {
+			t.Error("reconciliation should not be re queued")
 		}
 	})
 
@@ -76,7 +76,7 @@ func TestReplicationController_Instance_Phase(t *testing.T) {
 		if err == nil {
 			t.Error("reconciliation did not return error as expected")
 		}
-		if res.RequeueAfter != 120*time.Second {
+		if res.RequeueAfter != 30*time.Second {
 			t.Error("reconciliation did not requeue as expected")
 		}
 	})

--- a/pkg/controller/replication/replication_controller_test.go
+++ b/pkg/controller/replication/replication_controller_test.go
@@ -76,7 +76,7 @@ func TestReplicationController_Instance_Phase(t *testing.T) {
 		if err == nil {
 			t.Error("reconciliation did not return error as expected")
 		}
-		if res.RequeueAfter != 30*time.Second {
+		if res.RequeueAfter != 30 * time.Second {
 			t.Error("reconciliation did not requeue as expected")
 		}
 	})

--- a/pkg/controller/repository/repository_controller_test.go
+++ b/pkg/controller/repository/repository_controller_test.go
@@ -35,7 +35,7 @@ func buildReconcileWithFakeClientWithMocks(objs []runtime.Object) *ReconcileRepo
 }
 
 // TestRepositoryController_NonExistent_Instance
-// Test reconciliation with a non existent instance object which is expected to be requeued
+// Test reconciliation with a non existent instance object
 func TestRepositoryController_NonExistent_Instance(t *testing.T) {
 	repo := registriesv1alpha1.Repository{}
 
@@ -53,8 +53,8 @@ func TestRepositoryController_NonExistent_Instance(t *testing.T) {
 		t.Fatalf("reconcile returned error: (%v)", err)
 	}
 
-	if res.RequeueAfter != 30*time.Second {
-		t.Error("reconciliation did not requeue as expected")
+	if res.Requeue {
+		t.Error("reconciliation should not be re queued")
 	}
 }
 
@@ -77,7 +77,7 @@ func TestRepositoryController_Unready_Instance(t *testing.T) {
 	if err == nil {
 		t.Error("reconciliation did not return error as expected")
 	}
-	if !(res.RequeueAfter == 120*time.Second) {
+	if !(res.RequeueAfter == 30*time.Second) {
 		t.Error("reconciliation did not requeue as expected")
 	}
 }

--- a/pkg/controller/repository/repository_controller_test.go
+++ b/pkg/controller/repository/repository_controller_test.go
@@ -77,7 +77,7 @@ func TestRepositoryController_Unready_Instance(t *testing.T) {
 	if err == nil {
 		t.Error("reconciliation did not return error as expected")
 	}
-	if !(res.RequeueAfter == 30*time.Second) {
+	if !(res.RequeueAfter == 30 * time.Second) {
 		t.Error("reconciliation did not requeue as expected")
 	}
 }

--- a/pkg/controller/user/user_controller.go
+++ b/pkg/controller/user/user_controller.go
@@ -223,23 +223,14 @@ func (r *ReconcileUser) assertExistingUser(ctx context.Context, harborClient *h.
 		return err
 	}
 
-	patch := client.MergeFrom(user.DeepCopy())
 	if err == internal.ErrUserNotFound {
 		user.Status.PasswordHash = pwHash.Short()
-		if err = r.createUser(harborClient, user, pw); err != nil {
-			return err
-		}
-
-		return r.client.Status().Patch(context.Background(), user, patch)
+		return r.createUser(harborClient, user, pw)
 	}
 
 	if user.Status.PasswordHash != pwHash.Short() {
 		user.Status.PasswordHash = pwHash.Short()
 		if err = harborClient.Users().UpdateUserPasswordAsAdmin(int64(heldUser.UserID), pw); err != nil {
-			return err
-		}
-
-		if err = r.client.Status().Patch(context.Background(), user, patch); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/user/user_controller_test.go
+++ b/pkg/controller/user/user_controller_test.go
@@ -115,7 +115,7 @@ func TestUserController_Instance_Phase(t *testing.T) {
 		if err == nil {
 			t.Error("reconciliation did not return error as expected")
 		}
-		if res.RequeueAfter != 30*time.Second {
+		if res.RequeueAfter != 30 * time.Second {
 			t.Error("reconciliation did not requeue as expected")
 		}
 	})

--- a/pkg/controller/user/user_controller_test.go
+++ b/pkg/controller/user/user_controller_test.go
@@ -5,6 +5,8 @@ import (
 	"testing"
 	"time"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	registriesv1alpha1 "github.com/mittwald/harbor-operator/pkg/apis/registries/v1alpha1"
 	testingregistriesv1alpha1 "github.com/mittwald/harbor-operator/pkg/testing/registriesv1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -42,7 +44,12 @@ func TestUserController_Empty_User_Spec(t *testing.T) {
 
 	instanceSecret := testingregistriesv1alpha1.CreateSecret(instance.Name+"-harbor-core", ns)
 
-	u := registriesv1alpha1.User{}
+	u := registriesv1alpha1.User{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-user",
+			Namespace: ns,
+		},
+	}
 
 	r := buildReconcileWithFakeClientWithMocks([]runtime.Object{&u, &instance, &instanceSecret})
 
@@ -55,7 +62,7 @@ func TestUserController_Empty_User_Spec(t *testing.T) {
 
 	res, err := r.Reconcile(req)
 	if err != nil {
-		t.Fatalf("reconcile returned error: (%v)", err)
+		t.Fatalf("reconcile returned no error: %s", err)
 	}
 
 	if !res.Requeue {
@@ -108,7 +115,7 @@ func TestUserController_Instance_Phase(t *testing.T) {
 		if err == nil {
 			t.Error("reconciliation did not return error as expected")
 		}
-		if res.RequeueAfter != 120*time.Second {
+		if res.RequeueAfter != 30*time.Second {
 			t.Error("reconciliation did not requeue as expected")
 		}
 	})

--- a/pkg/controller/user/user_controller_test.go
+++ b/pkg/controller/user/user_controller_test.go
@@ -62,7 +62,7 @@ func TestUserController_Empty_User_Spec(t *testing.T) {
 
 	res, err := r.Reconcile(req)
 	if err != nil {
-		t.Fatalf("reconcile returned no error: %s", err)
+		t.Fatalf("reconcile returned error: %v", err)
 	}
 
 	if !res.Requeue {

--- a/pkg/internal/helper/hash.go
+++ b/pkg/internal/helper/hash.go
@@ -4,10 +4,9 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+
 	helmclient "github.com/mittwald/go-helm-client"
 )
-
-type InterfaceHash []byte
 
 // String returns the string value of an interface hash
 func (hash *InterfaceHash) String() string {

--- a/pkg/internal/helper/jsonpatch.go
+++ b/pkg/internal/helper/jsonpatch.go
@@ -7,16 +7,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-type jsonPatchOp struct {
-	Operation string      `json:"op"`
-	Path      string      `json:"path"`
-	Value     interface{} `json:"value,omitempty"`
-}
-
-type JSONPatch struct {
-	ops []jsonPatchOp
-}
-
 func (p *JSONPatch) Type() types.PatchType {
 	return types.JSONPatchType
 }

--- a/pkg/internal/helper/k8s.go
+++ b/pkg/internal/helper/k8s.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
-
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"

--- a/pkg/internal/helper/types.go
+++ b/pkg/internal/helper/types.go
@@ -1,0 +1,13 @@
+package helper
+
+type InterfaceHash []byte
+
+type jsonPatchOp struct {
+	Operation string      `json:"op"`
+	Path      string      `json:"path"`
+	Value     interface{} `json:"value,omitempty"`
+}
+
+type JSONPatch struct {
+	ops []jsonPatchOp
+}


### PR DESCRIPTION
## Common
- wait for harbor to become ready
- the parent instance will become the owner for all corresponding crs
- small refactoring of helper-types
- remove finalizers for replications and registries if they doesn't exist
- do not requeue a reconciled object if it has no errors

## Replication
- make IDs optional
- helm-chart fix
- wait for referenced registry to become ready

## User
- fix edge case of user creation: change password only if it has changed
