### PR TITLE
superficial controller improvements

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -196,7 +196,7 @@ func addMetrics(ctx context.Context, cfg *rest.Config, namespace string,
 		log.Info("Could not create ServiceMonitor object", "error", err.Error())
 		// If this operator is deployed to a cluster without the prometheus-operator running, it will return
 		// ErrServiceMonitorNotPresent, which can be used to safely skip ServiceMonitor creation.
-		if err == metrics.ErrServiceMonitorNotPresent {
+		if errors.Is(err, metrics.ErrServiceMonitorNotPresent) {
 			log.Info("Install prometheus-operator in your cluster to create ServiceMonitor objects",
 				"error", err.Error())
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -7,7 +7,7 @@ import (
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager.
 var AddToManagerFuncs []func(manager.Manager) error
 
-// AddToManager adds all Controllers to the Manager
+// AddToManager adds all Controllers to the Manager.
 func AddToManager(m manager.Manager) error {
 	for _, f := range AddToManagerFuncs {
 		if err := f(m); err != nil {

--- a/pkg/controller/instance/instance_controller.go
+++ b/pkg/controller/instance/instance_controller.go
@@ -73,10 +73,10 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	return nil
 }
 
-// blank assignment to verify that ReconcileInstance implements reconcile.Reconciler
+// blank assignment to verify that ReconcileInstance implements reconcile.Reconciler.
 var _ reconcile.Reconciler = &ReconcileInstance{}
 
-// ReconcileInstance reconciles a Instance object
+// ReconcileInstance reconciles a Instance object.
 type ReconcileInstance struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver.
@@ -161,12 +161,9 @@ func (r *ReconcileInstance) Reconcile(request reconcile.Request) (reconcile.Resu
 		// Creating a spec hash of the chart spec pre-installation
 		// ensures that it is set in "InstanceStatusPhaseReady", preventing the controller
 		// to jump right back into "InstanceStatusPhaseInstalling"
-		specHash, err := helper.CreateSpecHash(chartSpec)
-		if err != nil {
+		if specHash, err := helper.CreateSpecHash(chartSpec); err != nil {
 			return reconcile.Result{}, err
-		}
-
-		if harbor.Status.SpecHash == "" {
+		} else if harbor.Status.SpecHash == "" {
 			harbor.Status.SpecHash = specHash
 			return r.updateInstanceCR(ctx, originalInstance, harbor)
 		}
@@ -205,7 +202,7 @@ func (r *ReconcileInstance) Reconcile(request reconcile.Request) (reconcile.Resu
 	return r.updateInstanceCR(ctx, originalInstance, harbor)
 }
 
-// reconcileTerminatingInstance triggers a helm uninstall for the created release
+// reconcileTerminatingInstance triggers a helm uninstall for the created release.
 func (r *ReconcileInstance) reconcileTerminatingInstance(ctx context.Context, log logr.Logger,
 	harbor *registriesv1alpha1.Instance) error {
 	if harbor == nil {
@@ -258,7 +255,7 @@ func (r *ReconcileInstance) updateInstanceCR(ctx context.Context, originalInstan
 	return reconcile.Result{Requeue: true}, nil
 }
 
-// updateHelmRepos updates helm chart repositories
+// updateHelmRepos updates helm chart repositories.
 func (r *ReconcileInstance) updateHelmRepos() error {
 	helmClient, err := r.helmClientReceiver(config.Config.HelmClientRepositoryCachePath,
 		config.Config.HelmClientRepositoryConfigPath, "")
@@ -269,7 +266,7 @@ func (r *ReconcileInstance) updateHelmRepos() error {
 	return helmClient.UpdateChartRepos()
 }
 
-// installOrUpgradeHelmChart installs and upgrades a helm chart
+// installOrUpgradeHelmChart installs and upgrades a helm chart.
 func (r *ReconcileInstance) installOrUpgradeHelmChart(helmChart *helmclient.ChartSpec) error {
 	helmClient, err := r.helmClientReceiver(config.Config.HelmClientRepositoryCachePath,
 		config.Config.HelmClientRepositoryConfigPath, helmChart.Namespace)
@@ -280,7 +277,7 @@ func (r *ReconcileInstance) installOrUpgradeHelmChart(helmChart *helmclient.Char
 	return helmClient.InstallOrUpgradeChart(helmChart)
 }
 
-// uninstallHelmRelease uninstalls a helm release
+// uninstallHelmRelease uninstalls a helm release.
 func (r *ReconcileInstance) uninstallHelmRelease(helmChart *helmclient.ChartSpec) error {
 	helmClient, err := r.helmClientReceiver(config.Config.HelmClientRepositoryCachePath,
 		config.Config.HelmClientRepositoryConfigPath, helmChart.Namespace)

--- a/pkg/controller/instancechartrepo/instancechartrepo_controller.go
+++ b/pkg/controller/instancechartrepo/instancechartrepo_controller.go
@@ -191,7 +191,7 @@ func (r *ReconcileInstanceChartRepo) specToRepoEntry(ctx context.Context,
 	return &entry, nil
 }
 
-// getSecret gets and returns a kubernetes secret
+// getSecret gets and returns a kubernetes secret.
 func (r *ReconcileInstanceChartRepo) getSecret(ctx context.Context,
 	cr *registriesv1alpha1.InstanceChartRepo) (*corev1.Secret, error) {
 	var secret corev1.Secret

--- a/pkg/controller/instancechartrepo/instancechartrepo_controller_test.go
+++ b/pkg/controller/instancechartrepo/instancechartrepo_controller_test.go
@@ -34,7 +34,7 @@ const (
 	testSecretCaFile   = "testcafile"
 )
 
-// newTestReconciler returns a reconcile with fake client, schemes and mock objects
+// newTestReconciler returns a reconcile with fake client, schemes and mock objects.
 func newTestReconciler(objs []runtime.Object) *ReconcileInstanceChartRepo {
 	s := scheme.Scheme
 

--- a/pkg/controller/user/user_controller.go
+++ b/pkg/controller/user/user_controller.go
@@ -95,19 +95,17 @@ type ReconcileUser struct {
 // Note:
 // The Controller will requeue the Request to be processed again if the returned error is non-nil or
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
-func (r *ReconcileUser) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+func (r *ReconcileUser) Reconcile(request reconcile.Request) (result reconcile.Result, err error) {
 	reqLogger := log.WithValues("Request.Namespace", request.Namespace, "Request.Name", request.Name)
 	reqLogger.Info("Reconciling User")
 
 	now := metav1.Now()
 	ctx := context.Background()
 
-	var result reconcile.Result
-
 	// Fetch the User instance
 	user := &registriesv1alpha1.User{}
 
-	err := r.client.Get(ctx, request.NamespacedName, user)
+	err = r.client.Get(ctx, request.NamespacedName, user)
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.

--- a/pkg/controller/user/user_controller_test.go
+++ b/pkg/controller/user/user_controller_test.go
@@ -147,7 +147,6 @@ func TestUserController_Instance_Phase(t *testing.T) {
 	})
 }
 
-// TestUserController_User_Deletion
 func TestUserController_User_Deletion(t *testing.T) {
 	instance := testingregistriesv1alpha1.CreateInstance(instanceName, ns)
 	instance.Status.Phase.Name = registriesv1alpha1.InstanceStatusPhaseReady

--- a/pkg/internal/helper/hash.go
+++ b/pkg/internal/helper/hash.go
@@ -20,7 +20,7 @@ func (hash *InterfaceHash) Short() string {
 
 // GenerateHashFromInterfaces returns a hash sum based on a slice of given interfaces.
 func GenerateHashFromInterfaces(interfaces []interface{}) (InterfaceHash, error) {
-	var hashSrc []byte
+	hashSrc := make([]byte, len(interfaces))
 
 	for _, in := range interfaces {
 		chainElem, err := json.Marshal(in)

--- a/pkg/internal/helper/helper_test.go
+++ b/pkg/internal/helper/helper_test.go
@@ -103,7 +103,24 @@ func TestCreateSpecHash(t *testing.T) {
 	hash, err := CreateSpecHash(spec)
 
 	assert.NoError(t, err)
-	assert.NotNil(t, hash)
+
+	hash2, err := CreateSpecHash(spec)
+
+	assert.NoError(t, err)
+
+	if assert.NotNil(t, hash) && assert.NotNil(t, hash2) {
+		assert.Equal(t, hash, hash2)
+	}
+
+	spec.ChartName = "foo"
+
+	hash3, err := CreateSpecHash(spec)
+
+	assert.NoError(t, err)
+
+	if assert.NotNil(t, hash3) {
+		assert.NotEqual(t, hash, hash3)
+	}
 }
 
 func TestPushFinalizer(t *testing.T) {


### PR DESCRIPTION
- Drop unused arguments
- Fix upper/lower-casing in comments, add comment dots
- Compare error types via 'errors.Is()', not 'if err == type [...]'
- In 'GenerateHashFromInterfaces()', pre-allocate the 'hashSrc' slice
- Make the TestCreateSpecHash() testcase check that hashes are not varying