### PR TITLE
use updated bump-version-action

### DIFF
--- a/.github/workflows/verify-codegen.yml
+++ b/.github/workflows/verify-codegen.yml
@@ -2,9 +2,6 @@ name: Verify code generation integrity
 
 on: pull_request
 
-env:
-  OPERATOR_SDK_VERSION: v1.1.0
-
 jobs:
   verify-operator-sdk:
     name: Verify Code Generation

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -119,11 +119,3 @@ jobs:
 
       - name: Push images
         run: docker push "$IMAGE_NAME:latest" && docker push "$IMAGE_NAME:${GITHUB_REF##*/}"
-
-      - name: Run chart version bump
-        uses: mittwald/bump-app-version-action@"${BUMP_APP_VERSION_ACTION_VERSION}"
-        with:
-          mode: 'publish'
-          chartYaml: './deploy/helm-chart/harbor-operator/Chart.yaml'
-        env:
-          GITHUB_TOKEN: "${{ secrets.githubToken }}"

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -13,8 +13,7 @@ env:
   KUBECONFIG: /tmp/kubeconfig
   IMAGE_NAME: quay.io/mittwald/harbor-operator
   REGISTRY_URL: quay.io/mittwald
-  GOLANGCI_LINT_VERSION: v1.36.0
-  BUMP_APP_VERSION_ACTION_VERSION: v0.2.1
+  GOLANGCI_LINT_VERSION: v1.37.1
 
 jobs:
   lint:
@@ -119,3 +118,12 @@ jobs:
 
       - name: Push images
         run: docker push "$IMAGE_NAME:latest" && docker push "$IMAGE_NAME:${GITHUB_REF##*/}"
+
+      - name: Bump chart version
+        uses: mittwald/bump-app-version-action@v1
+        with:
+          mode: 'publish'
+          chartYaml: './deploy/helm-chart/harbor-operator/Chart.yaml'
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUBTOKEN }}"
+          HELM_REPO_PASSWORD: "${{ secrets.HELM_REPO_PASSWORD }}"

--- a/README.md
+++ b/README.md
@@ -19,16 +19,12 @@ A Kubernetes operator for automated management of [Goharbor](https://github.com/
 - [Example Deployment](#Example-Deployment)
 
 ### Installation
-Install this operator using Helm:
-```shell script
-helm repo add mittwald https://helm.mittwald.de
-helm repo update
-helm install harbor-operator mittwald/harbor-operator --namespace my-namespace
-```
 
 The helm chart of this operator can be found under [./deploy/helm-chart/harbor-operator](./deploy/helm-chart/harbor-operator).
-
-Alternatively, you can refer to the [mittwald/helm-charts](https://github.com/mittwald/helm-charts) repository.
+Install this operator using Helm:
+```shell script
+helm install harbor-operator . --namespace my-namespace
+```
 
 ### Architecture
 

--- a/README.md
+++ b/README.md
@@ -20,10 +20,13 @@ A Kubernetes operator for automated management of [Goharbor](https://github.com/
 
 ### Installation
 
-The helm chart of this operator can be found under [./deploy/helm-chart/harbor-operator](./deploy/helm-chart/harbor-operator).
-Install this operator using Helm:
+The helm chart of this operator can be found in this repository under [./deploy/helm-chart/harbor-operator](./deploy/helm-chart/harbor-operator)
+Alternatively, you can use the [helm.mittwald.de](https://helm.mittwald.de) chart repository:
+
 ```shell script
-helm install harbor-operator . --namespace my-namespace
+helm repo add mittwald https://helm.mittwald.de
+helm repo update
+helm install harbor-operator mittwald/harbor-operator --namespace my-namespace
 ```
 
 ### Architecture


### PR DESCRIPTION
As [mittwald/helm-charts](https://github.com/mittwald/helm-charts) now is archived, the `v1` [mittwald/bump-app-version-action](https://github.com/mittwald/bump-app-version-action) now supports pushing to the new chart repository.