### PR TITLE
feat(deployment): allow add custom env values

### DIFF
--- a/deploy/chart/Chart.yaml
+++ b/deploy/chart/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: harbor-operator
 description: A Kubernetes operator for managing goharbor instances
 type: application
-version: 1.6.3
+version: 1.6.4
 appVersion: v1.6.3

--- a/deploy/chart/templates/operator.yaml
+++ b/deploy/chart/templates/operator.yaml
@@ -25,7 +25,7 @@ spec:
         - name: {{ .Values.image.pullSecret }}
       {{- end }}
       containers:
-        - name:  {{ .Chart.Name }}
+        - name: {{ .Chart.Name }}
 {{- if .Values.image.tag }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
 {{- else }}
@@ -36,6 +36,10 @@ spec:
             - /manager
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- with .Values.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 10 }}
+          {{- end }}
           env:
             - name: WATCH_NAMESPACE
               valueFrom:
@@ -47,10 +51,10 @@ spec:
                   fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "harbor-operator"
-            - name: HELM_CLIENT_REPOSITORY_CACHE_PATH
-              value: {{ .Values.env.helmClientRepositoryCachePath }}
-            - name: HELM_CLIENT_REPOSITORY_CONFIG_PATH
-              value: {{ .Values.env.helmClientRepositoryConfigPath }}
+          {{- range $key, $value := $.Values.env }}
+            - name: {{ $key | snakecase | upper }}
+              value: "{{ $value }}"
+          {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
       {{- toYaml . | nindent 8 }}

--- a/deploy/chart/values.yaml
+++ b/deploy/chart/values.yaml
@@ -5,6 +5,10 @@ image:
   pullPolicy: Always
   pullSecret: {}
 
+envFrom:
+#  - configMapRef:
+#      name: env-from-configmap
+
 env:
   helmClientRepositoryCachePath: /tmp/.helmcache
   helmClientRepositoryConfigPath: /tmp/.helmrepo


### PR DESCRIPTION
Hello

Allow environment values to be passed to the operator container from a list of values defined by the `env` setting, and/or values from an object (configmap or secrets) with the `envFrom` setting.

I keep the compatibility of already defined env values with a range to transform the key value from a camelCase to snakeCase and transform it to uppercase.
```
          {{- range $key, $value := $.Values.env }}
            - name: {{ $key | snakecase | upper }}
              value: "{{ $value }}"
          {{- end }}
```